### PR TITLE
feat(config): add chat_language setting to pilot.yaml

### DIFF
--- a/framework/templates/claude-md-template.md
+++ b/framework/templates/claude-md-template.md
@@ -6,7 +6,7 @@ I am a software engineer. I use Claude Code as my AI engineering team to handle 
 ## My Workflow Preferences
 
 ### Communication
-- Speak to me in Chinese (Mandarin) for discussions and explanations
+- Speak to me in {{CHAT_LANGUAGE}} for discussions and explanations
 - Code, commits, PR descriptions, and technical documentation should be in English
 - Be concise — I don't need lengthy explanations for things I already understand
 - When unsure, ask me rather than guessing

--- a/init.js
+++ b/init.js
@@ -166,6 +166,7 @@ function writeYaml(config) {
   for (const skill of (config.skills || [])) {
     yaml += `  - ${skill}\n`;
   }
+  yaml += `\nchat_language: ${config.chat_language || 'English'}\n`;
   if (config.build) {
     yaml += '\nbuild:\n';
     for (const [key, value] of Object.entries(config.build)) {
@@ -356,7 +357,9 @@ async function main() {
       // Replace {{REPO}} placeholder with first repo
       let template = fs.readFileSync(claudeMdSrc, 'utf-8');
       const primaryRepo = (config.repos && config.repos[0]) || 'your-org/your-repo';
+      const chatLang = config.chat_language || 'English';
       template = template.replace(/\{\{REPO\}\}/g, primaryRepo);
+      template = template.replace(/\{\{CHAT_LANGUAGE\}\}/g, chatLang);
       fs.writeFileSync(claudeMdDest, template, 'utf-8');
       console.log('  [INSTALL] CLAUDE.md');
       installed++;

--- a/modernize-java-pilot.yaml
+++ b/modernize-java-pilot.yaml
@@ -16,6 +16,9 @@ skills:
 # AI platform
 ai_platform: claude-code
 
+# Chat language
+chat_language: Chinese (Mandarin)
+
 # Default modes
 defaults:
   dev_issue_mode: normal

--- a/pilot.yaml.template
+++ b/pilot.yaml.template
@@ -17,6 +17,11 @@ skills: []
 # Options: copilot-cli, claude-code
 ai_platform: claude-code
 
+# Chat language — the language Claude uses for discussions and explanations
+# Code, commits, and PRs are always in English regardless of this setting.
+# Examples: English, Chinese (Mandarin), Japanese, etc.
+chat_language: English
+
 # Default modes for automation
 defaults:
   dev_issue_mode: normal       # normal = interactive, auto = fully automated


### PR DESCRIPTION
Make the chat language configurable instead of hardcoding Chinese. Default is English; modernize-java preset uses Chinese (Mandarin). The template uses {{CHAT_LANGUAGE}} placeholder resolved by init.js.