### PR TITLE
ci: add PR gate workflow requiring npm build to pass

### DIFF
--- a/.github/workflows/pr-gate.yml
+++ b/.github/workflows/pr-gate.yml
@@ -1,0 +1,28 @@
+name: PR Gate
+
+on:
+  pull_request:
+    branches: [main]
+
+jobs:
+  build:
+    name: Build Dashboard
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: dashboard
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+          cache-dependency-path: dashboard/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build
+        run: npm run build


### PR DESCRIPTION
This pull request adds a new GitHub Actions workflow to automate the build process for pull requests targeting the `main` branch. The workflow is defined in `.github/workflows/pr-gate.yml` and ensures that the dashboard project builds successfully before merging.

Continuous integration:

* Added a new workflow file `.github/workflows/pr-gate.yml` that triggers on pull requests to `main`, checks out the code, sets up Node.js 20 with npm caching, installs dependencies, and runs the dashboard build process.