### PR TITLE
fix(dashboard): use correct GitHub CLI statusCheckRollup fields 

### DIFF
--- a/dashboard/__tests__/lib/github.test.ts
+++ b/dashboard/__tests__/lib/github.test.ts
@@ -78,32 +78,35 @@ describe('classifyPRAction', () => {
   it('returns "draft" for draft PRs even with CI failures', () => {
     expect(classifyPRAction(makePR({
       isDraft: true,
-      statusCheckRollup: [{ state: 'FAILURE' }],
+      statusCheckRollup: [{ status: 'COMPLETED', conclusion: 'FAILURE' }],
     }))).toBe('draft');
   });
 
   it('returns "ci_failing" when any check has FAILURE', () => {
     expect(classifyPRAction(makePR({
-      statusCheckRollup: [{ state: 'SUCCESS' }, { state: 'FAILURE' }],
+      statusCheckRollup: [
+        { status: 'COMPLETED', conclusion: 'SUCCESS' },
+        { status: 'COMPLETED', conclusion: 'FAILURE' },
+      ],
     }))).toBe('ci_failing');
   });
 
   it('returns "ci_failing" when all checks are FAILURE', () => {
     expect(classifyPRAction(makePR({
-      statusCheckRollup: [{ state: 'FAILURE' }],
+      statusCheckRollup: [{ status: 'COMPLETED', conclusion: 'FAILURE' }],
     }))).toBe('ci_failing');
   });
 
   it('returns "changes_requested" when reviewDecision is CHANGES_REQUESTED', () => {
     expect(classifyPRAction(makePR({
-      statusCheckRollup: [{ state: 'SUCCESS' }],
+      statusCheckRollup: [{ status: 'COMPLETED', conclusion: 'SUCCESS' }],
       reviewDecision: 'CHANGES_REQUESTED',
     }))).toBe('changes_requested');
   });
 
   it('returns "has_unresolved_comments" when unresolvedThreadCount > 0', () => {
     expect(classifyPRAction(makePR({
-      statusCheckRollup: [{ state: 'SUCCESS' }],
+      statusCheckRollup: [{ status: 'COMPLETED', conclusion: 'SUCCESS' }],
       reviewDecision: 'APPROVED',
       unresolvedThreadCount: 3,
     }))).toBe('has_unresolved_comments');
@@ -111,14 +114,14 @@ describe('classifyPRAction', () => {
 
   it('returns "ready_to_merge" when CI passes and approved', () => {
     expect(classifyPRAction(makePR({
-      statusCheckRollup: [{ state: 'SUCCESS' }],
+      statusCheckRollup: [{ status: 'COMPLETED', conclusion: 'SUCCESS' }],
       reviewDecision: 'APPROVED',
     }))).toBe('ready_to_merge');
   });
 
   it('returns "ready_to_merge" with unresolvedThreadCount=0', () => {
     expect(classifyPRAction(makePR({
-      statusCheckRollup: [{ state: 'SUCCESS' }],
+      statusCheckRollup: [{ status: 'COMPLETED', conclusion: 'SUCCESS' }],
       reviewDecision: 'APPROVED',
       unresolvedThreadCount: 0,
     }))).toBe('ready_to_merge');
@@ -126,21 +129,21 @@ describe('classifyPRAction', () => {
 
   it('returns "review_pending" when reviewDecision is REVIEW_REQUIRED', () => {
     expect(classifyPRAction(makePR({
-      statusCheckRollup: [{ state: 'SUCCESS' }],
+      statusCheckRollup: [{ status: 'COMPLETED', conclusion: 'SUCCESS' }],
       reviewDecision: 'REVIEW_REQUIRED',
     }))).toBe('review_pending');
   });
 
   it('returns "review_pending" when reviewDecision is empty string', () => {
     expect(classifyPRAction(makePR({
-      statusCheckRollup: [{ state: 'SUCCESS' }],
+      statusCheckRollup: [{ status: 'COMPLETED', conclusion: 'SUCCESS' }],
       reviewDecision: '',
     }))).toBe('review_pending');
   });
 
   it('returns "waiting" when CI is pending and approved', () => {
     expect(classifyPRAction(makePR({
-      statusCheckRollup: [{ state: 'PENDING' }],
+      statusCheckRollup: [{ status: 'IN_PROGRESS', conclusion: '' }],
       reviewDecision: 'APPROVED',
     }))).toBe('waiting');
   });
@@ -162,14 +165,14 @@ describe('classifyPRAction', () => {
   // Priority order tests
   it('ci_failing takes priority over changes_requested', () => {
     expect(classifyPRAction(makePR({
-      statusCheckRollup: [{ state: 'FAILURE' }],
+      statusCheckRollup: [{ status: 'COMPLETED', conclusion: 'FAILURE' }],
       reviewDecision: 'CHANGES_REQUESTED',
     }))).toBe('ci_failing');
   });
 
   it('changes_requested takes priority over has_unresolved_comments', () => {
     expect(classifyPRAction(makePR({
-      statusCheckRollup: [{ state: 'SUCCESS' }],
+      statusCheckRollup: [{ status: 'COMPLETED', conclusion: 'SUCCESS' }],
       reviewDecision: 'CHANGES_REQUESTED',
       unresolvedThreadCount: 5,
     }))).toBe('changes_requested');
@@ -177,7 +180,7 @@ describe('classifyPRAction', () => {
 
   it('has_unresolved_comments takes priority over ready_to_merge', () => {
     expect(classifyPRAction(makePR({
-      statusCheckRollup: [{ state: 'SUCCESS' }],
+      statusCheckRollup: [{ status: 'COMPLETED', conclusion: 'SUCCESS' }],
       reviewDecision: 'APPROVED',
       unresolvedThreadCount: 1,
     }))).toBe('has_unresolved_comments');
@@ -185,30 +188,57 @@ describe('classifyPRAction', () => {
 
   it('treats all SUCCESS checks as CI pass', () => {
     expect(classifyPRAction(makePR({
-      statusCheckRollup: [{ state: 'SUCCESS' }, { state: 'SUCCESS' }, { state: 'SUCCESS' }],
+      statusCheckRollup: [
+        { status: 'COMPLETED', conclusion: 'SUCCESS' },
+        { status: 'COMPLETED', conclusion: 'SUCCESS' },
+        { status: 'COMPLETED', conclusion: 'SUCCESS' },
+      ],
       reviewDecision: 'APPROVED',
     }))).toBe('ready_to_merge');
   });
 
-  it('treats mixed SUCCESS/PENDING as pending CI', () => {
+  it('treats mixed COMPLETED/IN_PROGRESS as pending CI', () => {
     expect(classifyPRAction(makePR({
-      statusCheckRollup: [{ state: 'SUCCESS' }, { state: 'PENDING' }],
+      statusCheckRollup: [
+        { status: 'COMPLETED', conclusion: 'SUCCESS' },
+        { status: 'IN_PROGRESS', conclusion: '' },
+      ],
       reviewDecision: 'APPROVED',
     }))).toBe('waiting');
   });
 
   it('returns "ci_failing" even when approved if CI fails', () => {
     expect(classifyPRAction(makePR({
-      statusCheckRollup: [{ state: 'FAILURE' }],
+      statusCheckRollup: [{ status: 'COMPLETED', conclusion: 'FAILURE' }],
       reviewDecision: 'APPROVED',
     }))).toBe('ci_failing');
   });
 
   it('treats undefined unresolvedThreadCount as no unresolved comments', () => {
     expect(classifyPRAction(makePR({
-      statusCheckRollup: [{ state: 'SUCCESS' }],
+      statusCheckRollup: [{ status: 'COMPLETED', conclusion: 'SUCCESS' }],
       reviewDecision: 'APPROVED',
       unresolvedThreadCount: undefined,
+    }))).toBe('ready_to_merge');
+  });
+
+  it('treats NEUTRAL conclusion as CI pass', () => {
+    expect(classifyPRAction(makePR({
+      statusCheckRollup: [
+        { status: 'COMPLETED', conclusion: 'SUCCESS' },
+        { status: 'COMPLETED', conclusion: 'NEUTRAL' },
+      ],
+      reviewDecision: 'APPROVED',
+    }))).toBe('ready_to_merge');
+  });
+
+  it('treats SKIPPED conclusion as CI pass', () => {
+    expect(classifyPRAction(makePR({
+      statusCheckRollup: [
+        { status: 'COMPLETED', conclusion: 'SUCCESS' },
+        { status: 'COMPLETED', conclusion: 'SKIPPED' },
+      ],
+      reviewDecision: 'APPROVED',
     }))).toBe('ready_to_merge');
   });
 });

--- a/dashboard/app/api/scrum/route.ts
+++ b/dashboard/app/api/scrum/route.ts
@@ -93,11 +93,13 @@ export async function GET() {
     const action = classifyPRAction(pr);
     const isBlocker = action === 'ci_failing' || action === 'changes_requested';
     const ciLabel = pr.statusCheckRollup?.length
-      ? pr.statusCheckRollup.every(c => c.state === 'SUCCESS')
+      ? pr.statusCheckRollup.every(c => c.conclusion === 'SUCCESS' || c.conclusion === 'NEUTRAL' || c.conclusion === 'SKIPPED')
         ? 'CI passing'
-        : pr.statusCheckRollup.some(c => c.state === 'FAILURE')
+        : pr.statusCheckRollup.some(c => c.conclusion === 'FAILURE')
           ? 'CI failing'
-          : 'CI pending'
+          : pr.statusCheckRollup.some(c => c.status !== 'COMPLETED')
+            ? 'CI pending'
+            : 'CI passing'
       : 'CI unknown';
     const reviewLabel = pr.reviewDecision === 'APPROVED'
       ? 'approved'

--- a/dashboard/lib/github.ts
+++ b/dashboard/lib/github.ts
@@ -159,11 +159,13 @@ export function classifyPRAction(pr: GHPR): PRAction {
   if (pr.isDraft) return 'draft';
 
   const ciState = pr.statusCheckRollup?.length
-    ? pr.statusCheckRollup.every(c => c.state === 'SUCCESS')
+    ? pr.statusCheckRollup.every(c => c.conclusion === 'SUCCESS' || c.conclusion === 'NEUTRAL' || c.conclusion === 'SKIPPED')
       ? 'pass'
-      : pr.statusCheckRollup.some(c => c.state === 'FAILURE')
+      : pr.statusCheckRollup.some(c => c.conclusion === 'FAILURE')
         ? 'fail'
-        : 'pending'
+        : pr.statusCheckRollup.some(c => c.status !== 'COMPLETED')
+          ? 'pending'
+          : 'pass'
     : 'pending';
 
   if (ciState === 'fail') return 'ci_failing';
@@ -250,7 +252,7 @@ export async function fetchRecentPRs(): Promise<ReportPR[]> {
           createdAt: string;
           mergedAt: string;
           reviewDecision: string;
-          statusCheckRollup: { state: string }[];
+          statusCheckRollup: { status: string; conclusion: string }[];
         }>;
         return prs.map(pr => ({
           number: pr.number,
@@ -260,11 +262,13 @@ export async function fetchRecentPRs(): Promise<ReportPR[]> {
           mergedAt: pr.mergedAt || '',
           reviewDecision: pr.reviewDecision || '',
           ciStatus: pr.statusCheckRollup?.length
-            ? pr.statusCheckRollup.every(c => c.state === 'SUCCESS')
+            ? pr.statusCheckRollup.every(c => c.conclusion === 'SUCCESS' || c.conclusion === 'NEUTRAL' || c.conclusion === 'SKIPPED')
               ? 'pass'
-              : pr.statusCheckRollup.some(c => c.state === 'FAILURE')
+              : pr.statusCheckRollup.some(c => c.conclusion === 'FAILURE')
                 ? 'fail'
-                : 'pending'
+                : pr.statusCheckRollup.some(c => c.status !== 'COMPLETED')
+                  ? 'pending'
+                  : 'pass'
             : 'unknown',
           repo,
         }));

--- a/dashboard/lib/types.ts
+++ b/dashboard/lib/types.ts
@@ -35,7 +35,7 @@ export interface GHPR {
   isDraft: boolean;
   createdAt: string;
   reviewDecision: string; // APPROVED | CHANGES_REQUESTED | REVIEW_REQUIRED | ""
-  statusCheckRollup: { state: string }[]; // SUCCESS | FAILURE | PENDING
+  statusCheckRollup: { status: string; conclusion: string }[]; // status: COMPLETED|IN_PROGRESS|QUEUED; conclusion: SUCCESS|FAILURE|NEUTRAL|...
   url: string;
   body: string;
   comments: { totalCount: number };


### PR DESCRIPTION
This pull request updates how CI status is handled for pull requests by switching from the legacy `state` field to the more granular `status` and `conclusion` fields for status checks. This improves compatibility with GitHub's current API and allows for more accurate classification of PR statuses such as pending, passing, or failing. The changes affect both the main logic and the associated tests.

**Core logic and type updates:**

* Updated the `GHPR` interface in `types.ts` so that `statusCheckRollup` now uses objects with `status` and `conclusion` fields instead of a single `state` field.
* Updated all logic in `classifyPRAction` and related CI status computations to use `conclusion` values (`SUCCESS`, `FAILURE`, `NEUTRAL`, `SKIPPED`) and `status` values (`COMPLETED`, `IN_PROGRESS`, etc.), improving the accuracy of PR CI classification. [[1]](diffhunk://#diff-952a15f99304d33c68ac68efad1e183dbff2b12e3a3b24139837500cf929a235L162-R168) [[2]](diffhunk://#diff-7c443b9c845c85591d58a1f2d43e05d1500aea9a53a9731fa1ad1c7c2ea6280eL96-R102) [[3]](diffhunk://#diff-952a15f99304d33c68ac68efad1e183dbff2b12e3a3b24139837500cf929a235L263-R271)

**Test and usage updates:**

* Refactored all test cases in `github.test.ts` to use the new `status` and `conclusion` fields, including new tests for `NEUTRAL` and `SKIPPED` conclusions. [[1]](diffhunk://#diff-ea21d1a370c49213b47499bfc1032f095fde666c20db91b098b1c8d5b7f0c2f5L81-R146) [[2]](diffhunk://#diff-ea21d1a370c49213b47499bfc1032f095fde666c20db91b098b1c8d5b7f0c2f5L165-R243)
* Updated the expected shape of `statusCheckRollup` in `fetchRecentPRs` and related code to match the new structure.

These changes ensure that PR status classification is robust and up-to-date with GitHub's latest APIs.