### PR TITLE
fix(dashboard): reuse existing Windows Terminal window for new tabs

### DIFF
--- a/dashboard/lib/terminal.ts
+++ b/dashboard/lib/terminal.ts
@@ -76,6 +76,7 @@ export function openClaudeTerminal(issueUrlOrOpts: string | TerminalOptions, mod
     if (platform === 'win32') {
       try {
         spawn('wt.exe', [
+          '-w', '0',
           'new-tab',
           '--title', tabTitle,
           'cmd', '/k', cliCmd,


### PR DESCRIPTION
Add -w 0 flag to wt.exe so new tabs open in the most recent active window instead of spawning a new Windows Terminal instance.