### PR TITLE
feat(dashboard): add GitHub account switcher

### DIFF
--- a/dashboard/app/api/gh-account/route.ts
+++ b/dashboard/app/api/gh-account/route.ts
@@ -1,0 +1,96 @@
+// GET /api/gh-account — list authenticated GitHub accounts
+// POST /api/gh-account — switch active account
+
+import { NextRequest, NextResponse } from 'next/server';
+import { exec } from 'child_process';
+import { promisify } from 'util';
+
+const execAsync = promisify(exec);
+
+interface GHAccount {
+  user: string;
+  host: string;
+  active: boolean;
+}
+
+/** Parse `gh auth status` output into structured accounts */
+function parseAuthStatus(output: string): GHAccount[] {
+  const accounts: GHAccount[] = [];
+  let currentHost = 'github.com';
+
+  const lines = output.split('\n');
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i];
+
+    // Host line: "github.com" (no leading spaces)
+    const hostMatch = line.match(/^(\S+\.\S+)\s*$/);
+    if (hostMatch) {
+      currentHost = hostMatch[1];
+      continue;
+    }
+
+    // Account line: "✓ Logged in to github.com account frankliu20 (keyring)"
+    const accountMatch = line.match(/account (\S+?)[\s(]/);
+    if (accountMatch && line.includes('Logged in')) {
+      accounts.push({ user: accountMatch[1], host: currentHost, active: false });
+      continue;
+    }
+
+    // Active line: "- Active account: true"
+    const activeMatch = line.match(/Active account:\s*(true|false)/);
+    if (activeMatch && accounts.length > 0) {
+      accounts[accounts.length - 1].active = activeMatch[1] === 'true';
+    }
+  }
+
+  return accounts;
+}
+
+export async function GET() {
+  try {
+    // gh auth status may write to stderr or stdout depending on version/platform
+    const result = await execAsync('gh auth status', {
+      encoding: 'utf-8',
+      timeout: 10000,
+    });
+    const output = result.stderr || result.stdout;
+    const accounts = parseAuthStatus(output);
+    return NextResponse.json({ accounts });
+  } catch (err: any) {
+    // gh auth status may exit with non-zero but still output account info
+    const output = err.stderr || err.stdout || '';
+    const accounts = parseAuthStatus(output);
+    if (accounts.length > 0) {
+      return NextResponse.json({ accounts });
+    }
+    console.error('[gh-account] Failed to get auth status:', err);
+    return NextResponse.json({ accounts: [], error: 'Failed to get GitHub auth status' }, { status: 500 });
+  }
+}
+
+export async function POST(request: NextRequest) {
+  try {
+    const { user } = await request.json();
+    if (!user || typeof user !== 'string') {
+      return NextResponse.json({ error: 'Missing or invalid "user" field' }, { status: 400 });
+    }
+
+    await execAsync(`gh auth switch --user ${user}`, {
+      encoding: 'utf-8',
+      timeout: 10000,
+    });
+
+    // Return updated account list
+    try {
+      const { stderr } = await execAsync('gh auth status', { encoding: 'utf-8', timeout: 10000 });
+      const accounts = parseAuthStatus(stderr);
+      return NextResponse.json({ accounts });
+    } catch (statusErr: any) {
+      const accounts = parseAuthStatus(statusErr.stderr || '');
+      return NextResponse.json({ accounts });
+    }
+  } catch (err: any) {
+    console.error('[gh-account] Failed to switch account:', err);
+    return NextResponse.json({ error: 'Failed to switch GitHub account' }, { status: 500 });
+  }
+}

--- a/dashboard/app/hooks/index.ts
+++ b/dashboard/app/hooks/index.ts
@@ -2,3 +2,4 @@ export { useTaskStream } from './useTaskStream';
 export { useGitHubData } from './useGitHubData';
 export { useTheme } from './useTheme';
 export { useKeyboardShortcuts } from './useKeyboardShortcuts';
+export { useGHAccount } from './useGHAccount';

--- a/dashboard/app/hooks/useGHAccount.ts
+++ b/dashboard/app/hooks/useGHAccount.ts
@@ -1,0 +1,56 @@
+'use client';
+
+import { useState, useCallback, useEffect } from 'react';
+
+interface GHAccount {
+  user: string;
+  host: string;
+  active: boolean;
+}
+
+export function useGHAccount() {
+  const [accounts, setAccounts] = useState<GHAccount[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [switching, setSwitching] = useState(false);
+
+  const fetchAccounts = useCallback(async () => {
+    try {
+      const res = await fetch('/api/gh-account');
+      const json = await res.json();
+      setAccounts(json.accounts || []);
+    } catch (err) {
+      console.error('Failed to fetch GitHub accounts:', err);
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  const switchAccount = useCallback(async (user: string) => {
+    setSwitching(true);
+    try {
+      const res = await fetch('/api/gh-account', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ user }),
+      });
+      const json = await res.json();
+      if (json.accounts) {
+        setAccounts(json.accounts);
+      }
+      return true;
+    } catch (err) {
+      console.error('Failed to switch GitHub account:', err);
+      return false;
+    } finally {
+      setSwitching(false);
+    }
+  }, []);
+
+  const activeAccount = accounts.find((a) => a.active)?.user || '';
+
+  useEffect(() => {
+    fetchAccounts();
+  }, [fetchAccounts]);
+
+  return { accounts, activeAccount, loading, switching, switchAccount, refresh: fetchAccounts };
+}

--- a/dashboard/app/page.module.css
+++ b/dashboard/app/page.module.css
@@ -34,6 +34,17 @@
   gap: var(--space-3);
 }
 
+.accountSelector {
+  display: flex;
+  align-items: center;
+  gap: var(--space-1);
+  color: var(--color-fg-subtle);
+}
+
+.accountName {
+  font-size: var(--text-2xs);
+}
+
 .connectionStatus {
   display: flex;
   align-items: center;

--- a/dashboard/app/page.tsx
+++ b/dashboard/app/page.tsx
@@ -3,7 +3,7 @@
 import { Suspense, useState, useCallback, useMemo, useEffect } from 'react';
 import { useSearchParams, useRouter } from 'next/navigation';
 import { GHIssue, GHPR, PRAction, REPO_URL, ReviewConfig, CliTool, CLI_TOOL_CONFIG } from '@/lib/types';
-import { useTaskStream, useGitHubData, useTheme, useKeyboardShortcuts } from './hooks';
+import { useTaskStream, useGitHubData, useTheme, useKeyboardShortcuts, useGHAccount } from './hooks';
 import { ACTIVE_PHASES } from '@/lib/constants';
 import { cn } from '@/lib/utils';
 import { ToastProvider, useToast } from './components/ui/Toast';
@@ -79,6 +79,7 @@ function DashboardInner() {
 
   const { theme, toggleTheme } = useTheme();
   const { toast } = useToast();
+  const { accounts, activeAccount, switching, switchAccount } = useGHAccount();
 
   const { data: issueData, loading: issuesLoading, refresh: refreshIssues } =
     useGitHubData<IssueData>('/api/issues');
@@ -352,6 +353,38 @@ function DashboardInner() {
           <h1 className={styles.logo}>Copilot Dev Dashboard</h1>
         </div>
         <div className={styles.headerRight}>
+          {accounts.length > 1 ? (
+            <div className={styles.accountSelector}>
+              <Icon name="user" size={14} />
+              <Select
+                size_="sm"
+                value={activeAccount}
+                onChange={async (e) => {
+                  const ok = await switchAccount(e.target.value);
+                  if (ok) {
+                    toast({ title: 'Switched to ' + e.target.value, variant: 'success' });
+                    refreshIssues();
+                    refreshPRs();
+                  } else {
+                    toast({ title: 'Failed to switch account', variant: 'danger' });
+                  }
+                }}
+                disabled={switching}
+                title="Switch GitHub account"
+              >
+                {accounts.map((a) => (
+                  <option key={a.user} value={a.user}>
+                    {a.user}
+                  </option>
+                ))}
+              </Select>
+            </div>
+          ) : activeAccount && (
+            <div className={styles.accountSelector}>
+              <Icon name="user" size={14} />
+              <span className={styles.accountName}>{activeAccount}</span>
+            </div>
+          )}
           <Select
             size_="sm"
             value={cliTool}


### PR DESCRIPTION
## Summary
- Add a GitHub account switcher to the dashboard header, allowing users to switch between multiple `gh` CLI authenticated accounts
- When only one account exists, displays the username as read-only text
- When multiple accounts exist, shows a dropdown selector that calls `gh auth switch` and refreshes issues/PRs data

## New files
- `dashboard/app/api/gh-account/route.ts` — API route (GET list accounts, POST switch account)
- `dashboard/app/hooks/useGHAccount.ts` — React hook for account state management

## Modified files
- `dashboard/app/page.tsx` — account selector UI in header
- `dashboard/app/page.module.css` — styles for account selector
- `dashboard/app/hooks/index.ts` — export new hook

## Test plan
- [ ] Start dashboard with multiple `gh` accounts authenticated
- [ ] Verify account dropdown appears in header right area
- [ ] Switch account and confirm issues/PRs refresh with new account's data
- [ ] Test with single account — should show username as read-only text
- [ ] Test with no `gh` auth — selector should not appear

🤖 Generated with [Claude Code](https://claude.com/claude-code)