### PR TITLE
fix(dashboard): normalize repo URLs from pilot.yaml

### DIFF
--- a/dashboard/next.config.ts
+++ b/dashboard/next.config.ts
@@ -12,7 +12,9 @@ function loadPilotEnv(): Record<string, string> {
 
   try {
     const config = yaml.load(readFileSync(pilotYaml, 'utf-8')) as Record<string, unknown>;
-    const repos = (config.repos as string[]) || [];
+    const repos = ((config.repos as string[]) || []).map((r) =>
+      r.replace(/^https?:\/\/github\.com\//, '')
+    );
     return {
       NEXT_PUBLIC_GITHUB_REPO: repos[0] || '',
       NEXT_PUBLIC_GITHUB_REPOS: JSON.stringify(repos),


### PR DESCRIPTION
This pull request makes a small improvement to the repository configuration loading logic by normalizing GitHub repository URLs. Now, when loading repositories from the `pilot.yaml` file, any `https://github.com/` or `http://github.com/` prefixes are stripped from the repository paths.

- Normalized repository URLs in the `loadPilotEnv` function of `dashboard/next.config.ts` to remove `https://github.com/` or `http://github.com/` prefixes from entries in the `repos` array.