### PR TITLE
fix(init): handle full URL in repos config

### DIFF
--- a/init.js
+++ b/init.js
@@ -342,7 +342,9 @@ async function main() {
           ? 'y'  // Non-interactive: auto-clone
           : await askQuestion(`  Clone ${repo}? (Y/n): `);
         if (clone.toLowerCase() !== 'n') {
-          const gitUrl = `https://github.com/${repo}.git`;
+          const gitUrl = repo.startsWith('https://')
+            ? (repo.endsWith('.git') ? repo : `${repo}.git`)
+            : `https://github.com/${repo}.git`;
           console.log(`  [CLONE]  ${gitUrl}`);
           try {
             execSync(`git clone ${gitUrl}`, { cwd: workspace, stdio: 'inherit' });


### PR DESCRIPTION
## Summary
- Fix `init.js` to detect when a repo entry in `pilot.yaml` is already a full `https://` URL, avoiding double-prepending `https://github.com/`
- Closes [#24](https://github.com/frankliu20/dev-pilot/issues/24)

## Test plan
- [x] Syntax check passed (`node --check init.js`)
- [x] Manual test: verify clone works with full URL in `pilot.yaml`
- [x] Manual test: verify clone still works with short `org/repo` format

🤖 Generated with [Claude Code](https://claude.com/claude-code)