### PR TITLE
feat(platform): add GitLab and Azure DevOps support

### DIFF
--- a/dashboard/__tests__/api/scrum.test.ts
+++ b/dashboard/__tests__/api/scrum.test.ts
@@ -20,11 +20,13 @@ vi.mock('@/lib/github', () => ({
 
 vi.mock('@/lib/config', () => ({
   getWorkspace: vi.fn().mockReturnValue('/workspace'),
+  getConfig: vi.fn().mockReturnValue({ workspace: '/workspace', platform: 'github' }),
 }));
 
 vi.mock('@/lib/types', async (importOriginal) => ({
   ...(await importOriginal<typeof import('@/lib/types')>()),
   REPO: 'owner/repo',
+  REPO_URL: 'https://github.com/owner/repo',
 }));
 
 import { GET, POST, PATCH } from '@/app/api/scrum/route';

--- a/dashboard/__tests__/api/tasks-fix-comments.test.ts
+++ b/dashboard/__tests__/api/tasks-fix-comments.test.ts
@@ -8,6 +8,7 @@ vi.mock('@/lib/terminal', () => ({
 vi.mock('@/lib/types', async (importOriginal) => ({
   ...(await importOriginal<typeof import('@/lib/types')>()),
   REPO: 'owner/repo',
+  REPO_URL: 'https://github.com/owner/repo',
 }));
 
 import { POST } from '@/app/api/tasks/fix-comments/route';

--- a/dashboard/__tests__/api/tasks-review-pr.test.ts
+++ b/dashboard/__tests__/api/tasks-review-pr.test.ts
@@ -8,6 +8,7 @@ vi.mock('@/lib/terminal', () => ({
 vi.mock('@/lib/types', async (importOriginal) => ({
   ...(await importOriginal<typeof import('@/lib/types')>()),
   REPO: 'owner/repo',
+  REPO_URL: 'https://github.com/owner/repo',
 }));
 
 import { POST } from '@/app/api/tasks/review-pr/route';
@@ -59,7 +60,7 @@ describe('POST /api/tasks/review-pr', () => {
     expect(res.status).toBe(400);
 
     const body = await res.json();
-    expect(body.error).toContain('Invalid PR URL');
+    expect(body.error).toContain('Invalid PR/MR URL');
   });
 
   it('returns 400 when both prNumber and prUrl are missing', async () => {

--- a/dashboard/__tests__/api/tasks-review-pr.test.ts
+++ b/dashboard/__tests__/api/tasks-review-pr.test.ts
@@ -53,6 +53,19 @@ describe('POST /api/tasks/review-pr', () => {
     expect(body.message).toContain('#456');
   });
 
+  it('returns 200 with Azure DevOps pullrequest URL', async () => {
+    vi.mocked(openClaudeTerminal).mockReturnValue({ success: true });
+
+    const res = await POST(createRequest({
+      prUrl: 'https://dev.azure.com/org/project/_git/repo/pullrequest/42',
+    }));
+    expect(res.status).toBe(200);
+
+    const body = await res.json();
+    expect(body.success).toBe(true);
+    expect(body.message).toContain('#42');
+  });
+
   it('returns 400 for invalid prUrl format', async () => {
     const res = await POST(createRequest({
       prUrl: 'https://not-github.com/foo/bar',

--- a/dashboard/__tests__/lib/config.test.ts
+++ b/dashboard/__tests__/lib/config.test.ts
@@ -206,6 +206,86 @@ describe('config', () => {
     });
   });
 
+  describe('getRepoSlug()', () => {
+    it('returns bare slug as-is', async () => {
+      const fs = await mockFs();
+      const yaml = await mockYaml();
+      vi.mocked(fs.existsSync).mockReturnValue(true);
+      vi.mocked(fs.readFileSync).mockReturnValue('ok' as any);
+      vi.mocked(yaml.load).mockReturnValue({
+        workspace: '/ws',
+        repos: ['owner/repo'],
+        skills: [],
+      });
+
+      const { getRepoSlug } = await importConfig();
+      expect(getRepoSlug()).toBe('owner/repo');
+    });
+
+    it('extracts slug from full GitHub URL', async () => {
+      const fs = await mockFs();
+      const yaml = await mockYaml();
+      vi.mocked(fs.existsSync).mockReturnValue(true);
+      vi.mocked(fs.readFileSync).mockReturnValue('ok' as any);
+      vi.mocked(yaml.load).mockReturnValue({
+        workspace: '/ws',
+        repos: ['https://github.com/myorg/myrepo'],
+        skills: [],
+      });
+
+      const { getRepoSlug } = await importConfig();
+      expect(getRepoSlug()).toBe('myorg/myrepo');
+    });
+
+    it('extracts slug from GitLab self-hosted URL', async () => {
+      const { getRepoSlug } = await importConfig();
+      expect(getRepoSlug('https://gitlab.mycompany.com/team/project')).toBe('team/project');
+    });
+
+    it('extracts slug from Azure DevOps URL', async () => {
+      const { getRepoSlug } = await importConfig();
+      expect(getRepoSlug('https://dev.azure.com/org/project/_git/repo')).toBe('org/project');
+    });
+
+    it('accepts explicit repo param over config default', async () => {
+      const fs = await mockFs();
+      const yaml = await mockYaml();
+      vi.mocked(fs.existsSync).mockReturnValue(true);
+      vi.mocked(fs.readFileSync).mockReturnValue('ok' as any);
+      vi.mocked(yaml.load).mockReturnValue({
+        workspace: '/ws',
+        repos: ['https://github.com/default/repo'],
+        skills: [],
+      });
+
+      const { getRepoSlug } = await importConfig();
+      expect(getRepoSlug('https://gitlab.com/other/repo')).toBe('other/repo');
+    });
+  });
+
+  describe('getPlatform()', () => {
+    it('returns github by default', async () => {
+      const { getPlatform } = await importConfig();
+      expect(getPlatform()).toBe('github');
+    });
+
+    it('returns configured platform', async () => {
+      const fs = await mockFs();
+      const yaml = await mockYaml();
+      vi.mocked(fs.existsSync).mockReturnValue(true);
+      vi.mocked(fs.readFileSync).mockReturnValue('ok' as any);
+      vi.mocked(yaml.load).mockReturnValue({
+        workspace: '/ws',
+        repos: [],
+        skills: [],
+        platform: 'gitlab',
+      });
+
+      const { getPlatform } = await importConfig();
+      expect(getPlatform()).toBe('gitlab');
+    });
+  });
+
   describe('getDefaults()', () => {
     it('returns defaults from config', async () => {
       const fs = await mockFs();

--- a/dashboard/__tests__/lib/git-provider.test.ts
+++ b/dashboard/__tests__/lib/git-provider.test.ts
@@ -11,6 +11,7 @@ import {
   getCliBinary,
   repoUrl,
   cloneUrl,
+  shellEscape,
   repoSlugFromUrl,
   repoFromUrl,
   supportsGraphQL,
@@ -69,6 +70,26 @@ describe('getCliBinary', () => {
   });
 });
 
+// ── Shell escaping ────────────────────────────────────────────────────
+
+describe('shellEscape', () => {
+  it('wraps in single quotes', () => {
+    expect(shellEscape('hello')).toBe("'hello'");
+  });
+
+  it('escapes embedded single quotes', () => {
+    expect(shellEscape("it's")).toBe("'it'\\''s'");
+  });
+
+  it('neutralizes $() command substitution', () => {
+    expect(shellEscape('$(whoami)')).toBe("'$(whoami)'");
+  });
+
+  it('neutralizes backticks', () => {
+    expect(shellEscape('`id`')).toBe("'`id`'");
+  });
+});
+
 // ── Repo URL helpers ───────────────────────────────────────────────────
 
 describe('repoUrl', () => {
@@ -105,7 +126,7 @@ describe('repoSlugFromUrl', () => {
   });
 
   it('extracts slug from Azure DevOps URL', () => {
-    expect(repoSlugFromUrl('https://dev.azure.com/org/project/_git/repo')).toBe('org/project/repo');
+    expect(repoSlugFromUrl('https://dev.azure.com/org/project/_git/repo')).toBe('org/project');
   });
 
   it('strips .git suffix', () => {
@@ -195,10 +216,22 @@ describe('issueViewArgs', () => {
 });
 
 describe('issueCommentArgs', () => {
-  it('escapes quotes in body', () => {
+  it('uses shell-safe single quotes for body', () => {
     setMockPlatform('github');
     const result = issueCommentArgs('owner/repo', 1, 'say "hello"');
-    expect(result).toContain('\\"hello\\"');
+    expect(result).toContain("'say \"hello\"'");
+  });
+
+  it('escapes single quotes in body', () => {
+    setMockPlatform('github');
+    const result = issueCommentArgs('owner/repo', 1, "it's a test");
+    expect(result).toContain("'it'\\''s a test'");
+  });
+
+  it('prevents shell injection via $() in body', () => {
+    setMockPlatform('github');
+    const result = issueCommentArgs('owner/repo', 1, '$(rm -rf /)');
+    expect(result).toContain("'$(rm -rf /)'");
   });
 
   it('builds gitlab note args', () => {

--- a/dashboard/__tests__/lib/git-provider.test.ts
+++ b/dashboard/__tests__/lib/git-provider.test.ts
@@ -1,0 +1,315 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// Mock config to control platform
+const mockGetConfig = vi.fn();
+vi.mock('@/lib/config', () => ({
+  getConfig: (...args: any[]) => mockGetConfig(...args),
+}));
+
+import {
+  getPlatform,
+  getCliBinary,
+  repoUrl,
+  cloneUrl,
+  repoSlugFromUrl,
+  repoFromUrl,
+  supportsGraphQL,
+  issueListArgs,
+  issueViewArgs,
+  issueCommentArgs,
+  prListArgs,
+  prViewArgs,
+  prDiffArgs,
+  prCreateArgs,
+  prReviewApproveArgs,
+  authStatusCommand,
+} from '@/lib/git-provider';
+
+function setMockPlatform(platform: string) {
+  mockGetConfig.mockReturnValue({
+    workspace: '/mock',
+    repos: [],
+    platform,
+    skills: [],
+  });
+}
+
+beforeEach(() => {
+  setMockPlatform('github');
+});
+
+// ── Platform detection ─────────────────────────────────────────────────
+
+describe('getPlatform', () => {
+  it('returns github by default', () => {
+    mockGetConfig.mockReturnValue({ workspace: '/mock', repos: [], skills: [] });
+    expect(getPlatform()).toBe('github');
+  });
+
+  it('returns configured platform', () => {
+    setMockPlatform('gitlab');
+    expect(getPlatform()).toBe('gitlab');
+  });
+});
+
+describe('getCliBinary', () => {
+  it('returns gh for github', () => {
+    setMockPlatform('github');
+    expect(getCliBinary()).toBe('gh');
+  });
+
+  it('returns glab for gitlab', () => {
+    setMockPlatform('gitlab');
+    expect(getCliBinary()).toBe('glab');
+  });
+
+  it('returns az for azdevops', () => {
+    setMockPlatform('azdevops');
+    expect(getCliBinary()).toBe('az');
+  });
+});
+
+// ── Repo URL helpers ───────────────────────────────────────────────────
+
+describe('repoUrl', () => {
+  it('returns full URL as-is', () => {
+    expect(repoUrl('https://gitlab.mycompany.com/team/project')).toBe('https://gitlab.mycompany.com/team/project');
+  });
+
+  it('falls back to GitHub for bare slugs', () => {
+    expect(repoUrl('owner/repo')).toBe('https://github.com/owner/repo');
+  });
+});
+
+describe('cloneUrl', () => {
+  it('appends .git to full URL', () => {
+    expect(cloneUrl('https://gitlab.mycompany.com/team/project')).toBe('https://gitlab.mycompany.com/team/project.git');
+  });
+
+  it('does not double .git', () => {
+    expect(cloneUrl('https://github.com/owner/repo.git')).toBe('https://github.com/owner/repo.git');
+  });
+
+  it('uses github.com for bare slugs', () => {
+    expect(cloneUrl('owner/repo')).toBe('https://github.com/owner/repo.git');
+  });
+});
+
+describe('repoSlugFromUrl', () => {
+  it('extracts slug from GitHub URL', () => {
+    expect(repoSlugFromUrl('https://github.com/owner/repo/issues/123')).toBe('owner/repo');
+  });
+
+  it('extracts slug from GitLab self-hosted URL', () => {
+    expect(repoSlugFromUrl('https://gitlab.mycompany.com/team/project')).toBe('team/project');
+  });
+
+  it('extracts slug from Azure DevOps URL', () => {
+    expect(repoSlugFromUrl('https://dev.azure.com/org/project/_git/repo')).toBe('org/project/repo');
+  });
+
+  it('strips .git suffix', () => {
+    expect(repoSlugFromUrl('https://github.com/owner/repo.git')).toBe('owner/repo');
+  });
+});
+
+describe('repoFromUrl', () => {
+  it('extracts owner/repo from GitHub URL', () => {
+    expect(repoFromUrl('https://github.com/owner/repo/pull/123')).toBe('owner/repo');
+  });
+
+  it('extracts from GitLab self-hosted URL', () => {
+    expect(repoFromUrl('https://gitlab.mycompany.com/team/project/-/merge_requests/5')).toBe('team/project');
+  });
+
+  it('extracts from Azure DevOps URL', () => {
+    expect(repoFromUrl('https://dev.azure.com/myorg/myproject/_git/myrepo/pullrequest/42')).toBe('myorg/myproject');
+  });
+
+  it('returns null for invalid URLs', () => {
+    expect(repoFromUrl('not-a-url')).toBeNull();
+  });
+
+  it('returns null for URL with only host', () => {
+    expect(repoFromUrl('https://github.com/')).toBeNull();
+  });
+
+  it('strips .git from repo name', () => {
+    expect(repoFromUrl('https://github.com/owner/repo.git/something')).toBe('owner/repo');
+  });
+});
+
+// ── GraphQL support ────────────────────────────────────────────────────
+
+describe('supportsGraphQL', () => {
+  it('returns true for github', () => {
+    setMockPlatform('github');
+    expect(supportsGraphQL()).toBe(true);
+  });
+
+  it('returns false for gitlab', () => {
+    setMockPlatform('gitlab');
+    expect(supportsGraphQL()).toBe(false);
+  });
+
+  it('returns false for azdevops', () => {
+    setMockPlatform('azdevops');
+    expect(supportsGraphQL()).toBe(false);
+  });
+});
+
+// ── Issue commands ─────────────────────────────────────────────────────
+
+describe('issueListArgs', () => {
+  it('builds github args', () => {
+    setMockPlatform('github');
+    expect(issueListArgs('owner/repo', '--state open')).toBe('issue list --repo owner/repo --state open');
+  });
+
+  it('builds gitlab args', () => {
+    setMockPlatform('gitlab');
+    expect(issueListArgs('team/project')).toBe('issue list --repo team/project ');
+  });
+
+  it('builds azdevops args', () => {
+    setMockPlatform('azdevops');
+    expect(issueListArgs('org/project')).toBe('boards work-item list ');
+  });
+});
+
+describe('issueViewArgs', () => {
+  it('builds github args', () => {
+    setMockPlatform('github');
+    expect(issueViewArgs('owner/repo', 42)).toBe('issue view 42 --repo owner/repo');
+  });
+
+  it('builds gitlab args', () => {
+    setMockPlatform('gitlab');
+    expect(issueViewArgs('team/project', 10)).toBe('issue view 10 --repo team/project');
+  });
+
+  it('builds azdevops args', () => {
+    setMockPlatform('azdevops');
+    expect(issueViewArgs('org/project', 5)).toBe('boards work-item show --id 5');
+  });
+});
+
+describe('issueCommentArgs', () => {
+  it('escapes quotes in body', () => {
+    setMockPlatform('github');
+    const result = issueCommentArgs('owner/repo', 1, 'say "hello"');
+    expect(result).toContain('\\"hello\\"');
+  });
+
+  it('builds gitlab note args', () => {
+    setMockPlatform('gitlab');
+    const result = issueCommentArgs('team/project', 1, 'test');
+    expect(result).toContain('issue note 1');
+    expect(result).toContain('-m');
+  });
+});
+
+// ── PR / MR commands ───────────────────────────────────────────────────
+
+describe('prListArgs', () => {
+  it('builds github args', () => {
+    setMockPlatform('github');
+    expect(prListArgs('owner/repo', '--author @me')).toBe('pr list --repo owner/repo --author @me');
+  });
+
+  it('builds gitlab mr list args', () => {
+    setMockPlatform('gitlab');
+    expect(prListArgs('team/project')).toBe('mr list --repo team/project ');
+  });
+
+  it('builds azdevops args', () => {
+    setMockPlatform('azdevops');
+    expect(prListArgs('org/project')).toBe('repos pr list --repository org/project ');
+  });
+});
+
+describe('prViewArgs', () => {
+  it('builds github args', () => {
+    setMockPlatform('github');
+    expect(prViewArgs('owner/repo', 5)).toBe('pr view 5 --repo owner/repo ');
+  });
+
+  it('builds gitlab args', () => {
+    setMockPlatform('gitlab');
+    expect(prViewArgs('team/project', 5)).toBe('mr view 5 --repo team/project ');
+  });
+});
+
+describe('prDiffArgs', () => {
+  it('builds github args', () => {
+    setMockPlatform('github');
+    expect(prDiffArgs('owner/repo', 10)).toBe('pr diff 10 --repo owner/repo');
+  });
+
+  it('builds gitlab args', () => {
+    setMockPlatform('gitlab');
+    expect(prDiffArgs('team/project', 10)).toBe('mr diff 10 --repo team/project');
+  });
+});
+
+describe('prCreateArgs', () => {
+  it('builds github args', () => {
+    setMockPlatform('github');
+    const result = prCreateArgs('owner/repo', 'title', 'body');
+    expect(result).toContain('pr create --repo owner/repo');
+  });
+
+  it('builds gitlab mr create args', () => {
+    setMockPlatform('gitlab');
+    const result = prCreateArgs('team/project', 'title', 'body');
+    expect(result).toContain('mr create --repo team/project');
+    expect(result).toContain('--description');
+  });
+
+  it('builds azdevops args', () => {
+    setMockPlatform('azdevops');
+    const result = prCreateArgs('org/project', 'title', 'body');
+    expect(result).toContain('repos pr create');
+  });
+});
+
+describe('prReviewApproveArgs', () => {
+  it('builds github approve args', () => {
+    setMockPlatform('github');
+    const result = prReviewApproveArgs('owner/repo', 5, 'LGTM');
+    expect(result).toContain('pr review 5');
+    expect(result).toContain('--approve');
+  });
+
+  it('builds gitlab approve args', () => {
+    setMockPlatform('gitlab');
+    const result = prReviewApproveArgs('team/project', 5, 'LGTM');
+    expect(result).toContain('mr approve 5');
+  });
+
+  it('builds azdevops vote args', () => {
+    setMockPlatform('azdevops');
+    const result = prReviewApproveArgs('org/project', 5, 'LGTM');
+    expect(result).toContain('set-vote');
+    expect(result).toContain('--vote approve');
+  });
+});
+
+// ── Auth commands ──────────────────────────────────────────────────────
+
+describe('authStatusCommand', () => {
+  it('returns gh auth status for github', () => {
+    setMockPlatform('github');
+    expect(authStatusCommand()).toBe('gh auth status');
+  });
+
+  it('returns glab auth status for gitlab', () => {
+    setMockPlatform('gitlab');
+    expect(authStatusCommand()).toBe('glab auth status');
+  });
+
+  it('returns az account show for azdevops', () => {
+    setMockPlatform('azdevops');
+    expect(authStatusCommand()).toBe('az account show');
+  });
+});

--- a/dashboard/__tests__/lib/git-provider.test.ts
+++ b/dashboard/__tests__/lib/git-provider.test.ts
@@ -189,12 +189,12 @@ describe('issueListArgs', () => {
 
   it('builds gitlab args', () => {
     setMockPlatform('gitlab');
-    expect(issueListArgs('team/project')).toBe('issue list --repo team/project ');
+    expect(issueListArgs('team/project')).toBe('issue list --repo team/project');
   });
 
   it('builds azdevops args', () => {
     setMockPlatform('azdevops');
-    expect(issueListArgs('org/project')).toBe('boards work-item list ');
+    expect(issueListArgs('org/project')).toBe('boards work-item list');
   });
 });
 
@@ -252,24 +252,24 @@ describe('prListArgs', () => {
 
   it('builds gitlab mr list args', () => {
     setMockPlatform('gitlab');
-    expect(prListArgs('team/project')).toBe('mr list --repo team/project ');
+    expect(prListArgs('team/project')).toBe('mr list --repo team/project');
   });
 
   it('builds azdevops args', () => {
     setMockPlatform('azdevops');
-    expect(prListArgs('org/project')).toBe('repos pr list --repository org/project ');
+    expect(prListArgs('org/project')).toBe('repos pr list --repository org/project');
   });
 });
 
 describe('prViewArgs', () => {
   it('builds github args', () => {
     setMockPlatform('github');
-    expect(prViewArgs('owner/repo', 5)).toBe('pr view 5 --repo owner/repo ');
+    expect(prViewArgs('owner/repo', 5)).toBe('pr view 5 --repo owner/repo');
   });
 
   it('builds gitlab args', () => {
     setMockPlatform('gitlab');
-    expect(prViewArgs('team/project', 5)).toBe('mr view 5 --repo team/project ');
+    expect(prViewArgs('team/project', 5)).toBe('mr view 5 --repo team/project');
   });
 });
 

--- a/dashboard/__tests__/lib/github.test.ts
+++ b/dashboard/__tests__/lib/github.test.ts
@@ -33,9 +33,11 @@ vi.mock('@/lib/config', () => ({
   getConfig: vi.fn(() => ({
     workspace: '/mock/workspace',
     repos: ['owner/repo'],
+    platform: 'github',
     skills: [],
   })),
   getRepo: vi.fn(() => 'owner/repo'),
+  getRepoSlug: vi.fn((repo?: string) => repo || 'owner/repo'),
   getReviewRepos: vi.fn(() => ['owner/repo']),
   getWorkspace: vi.fn(() => '/mock/workspace'),
 }));

--- a/dashboard/app/api/gh-account/route.ts
+++ b/dashboard/app/api/gh-account/route.ts
@@ -1,9 +1,11 @@
-// GET /api/gh-account — list authenticated GitHub accounts
+// GET /api/gh-account — list authenticated accounts (GitHub/GitLab/AzDevOps)
 // POST /api/gh-account — switch active account
 
 import { NextRequest, NextResponse } from 'next/server';
 import { exec } from 'child_process';
 import { promisify } from 'util';
+import { getPlatform } from '@/lib/config';
+import { authStatusCommand } from '@/lib/git-provider';
 
 const execAsync = promisify(exec);
 
@@ -48,8 +50,9 @@ function parseAuthStatus(output: string): GHAccount[] {
 
 export async function GET() {
   try {
-    // gh auth status may write to stderr or stdout depending on version/platform
-    const result = await execAsync('gh auth status', {
+    const cmd = authStatusCommand();
+    // gh/glab auth status may write to stderr or stdout depending on version/platform
+    const result = await execAsync(cmd, {
       encoding: 'utf-8',
       timeout: 10000,
     });
@@ -57,32 +60,39 @@ export async function GET() {
     const accounts = parseAuthStatus(output);
     return NextResponse.json({ accounts });
   } catch (err: any) {
-    // gh auth status may exit with non-zero but still output account info
+    // gh/glab auth status may exit with non-zero but still output account info
     const output = err.stderr || err.stdout || '';
     const accounts = parseAuthStatus(output);
     if (accounts.length > 0) {
       return NextResponse.json({ accounts });
     }
     console.error('[gh-account] Failed to get auth status:', err);
-    return NextResponse.json({ accounts: [], error: 'Failed to get GitHub auth status' }, { status: 500 });
+    return NextResponse.json({ accounts: [], error: 'Failed to get auth status' }, { status: 500 });
   }
 }
 
 export async function POST(request: NextRequest) {
+  const platform = getPlatform();
   try {
     const { user } = await request.json();
     if (!user || typeof user !== 'string') {
       return NextResponse.json({ error: 'Missing or invalid "user" field' }, { status: 400 });
     }
 
-    await execAsync(`gh auth switch --user ${user}`, {
-      encoding: 'utf-8',
-      timeout: 10000,
-    });
+    // Only GitHub supports account switching via CLI
+    if (platform === 'github') {
+      await execAsync(`gh auth switch --user ${user}`, {
+        encoding: 'utf-8',
+        timeout: 10000,
+      });
+    } else {
+      return NextResponse.json({ error: `Account switching not supported for ${platform}` }, { status: 400 });
+    }
 
     // Return updated account list
     try {
-      const { stderr } = await execAsync('gh auth status', { encoding: 'utf-8', timeout: 10000 });
+      const cmd = authStatusCommand();
+      const { stderr } = await execAsync(cmd, { encoding: 'utf-8', timeout: 10000 });
       const accounts = parseAuthStatus(stderr);
       return NextResponse.json({ accounts });
     } catch (statusErr: any) {
@@ -91,6 +101,6 @@ export async function POST(request: NextRequest) {
     }
   } catch (err: any) {
     console.error('[gh-account] Failed to switch account:', err);
-    return NextResponse.json({ error: 'Failed to switch GitHub account' }, { status: 500 });
+    return NextResponse.json({ error: 'Failed to switch account' }, { status: 500 });
   }
 }

--- a/dashboard/app/api/report/route.ts
+++ b/dashboard/app/api/report/route.ts
@@ -9,15 +9,19 @@ import {
   fetchMyOpenPRs,
   classifyPRAction,
 } from '@/lib/github';
-import { REPO } from '@/lib/types';
+import { REPO, REPO_URL } from '@/lib/types';
+import { repoUrl as buildRepoUrl } from '@/lib/git-provider';
 
-/** Build a GitHub URL for a PR/issue, using the repo field if available */
-function prUrl(pr: { number: number; repo?: string }): string {
-  return `https://github.com/${pr.repo || REPO}/pull/${pr.number}`;
+/** Build a URL for a PR/issue, using the repo field if available */
+function prUrl(pr: { number: number; url?: string; repo?: string }): string {
+  if (pr.url) return pr.url;
+  const base = pr.repo ? buildRepoUrl(pr.repo) : REPO_URL;
+  return `${base}/pull/${pr.number}`;
 }
 function issueUrl(issue: { number: number; url?: string; repo?: string }): string {
   if (issue.url) return issue.url;
-  return `https://github.com/${issue.repo || REPO}/issues/${issue.number}`;
+  const base = issue.repo ? buildRepoUrl(issue.repo) : REPO_URL;
+  return `${base}/issues/${issue.number}`;
 }
 
 export async function GET() {

--- a/dashboard/app/api/scrum/route.ts
+++ b/dashboard/app/api/scrum/route.ts
@@ -1,5 +1,5 @@
 // GET   /api/scrum — generate scrum report (Done / Ongoing / Blocker) since last scrum mark
-// POST  /api/scrum — post status updates as comments to GitHub issues
+// POST  /api/scrum — post status updates as comments to issues
 // PATCH /api/scrum — update the "last scrum" timestamp mark
 
 import { NextRequest, NextResponse } from 'next/server';
@@ -15,6 +15,7 @@ import {
 } from '@/lib/github';
 import { getWorkspace } from '@/lib/config';
 import { REPO } from '@/lib/types';
+import { issueCommentArgs, getCliBinary } from '@/lib/git-provider';
 
 const execAsync = promisify(exec);
 
@@ -193,8 +194,10 @@ export async function POST(request: NextRequest) {
   for (const update of updates) {
     try {
       const targetRepo = update.repo || REPO;
+      const cli = getCliBinary();
+      const args = issueCommentArgs(targetRepo, update.issueNumber, update.comment);
       await execAsync(
-        `gh issue comment ${update.issueNumber} --repo ${targetRepo} --body "${update.comment.replace(/"/g, '\\"')}"`,
+        `${cli} ${args}`,
         { timeout: 15000 },
       );
       results.push({ number: update.issueNumber, success: true });

--- a/dashboard/app/api/scrum/route.ts
+++ b/dashboard/app/api/scrum/route.ts
@@ -14,7 +14,7 @@ import {
   classifyPRAction,
 } from '@/lib/github';
 import { getWorkspace } from '@/lib/config';
-import { REPO } from '@/lib/types';
+import { REPO, REPO_URL } from '@/lib/types';
 import { issueCommentArgs, getCliBinary } from '@/lib/git-provider';
 
 const execAsync = promisify(exec);
@@ -109,7 +109,7 @@ export async function GET() {
         : 'waiting review';
 
     const issueMatch = pr.title.match(/#(\d+)/);
-    const prUrl = pr.url || `https://github.com/${REPO}/pull/${pr.number}`;
+    const prUrl = pr.url || `${REPO_URL}/pull/${pr.number}`;
     items.push({
       number: pr.number,
       title: pr.title,
@@ -128,7 +128,7 @@ export async function GET() {
   for (const pr of openPRsRaw) {
     const m = pr.title.match(/#(\d+)/);
     if (m) {
-      issueToPR.set(parseInt(m[1]), { number: pr.number, url: pr.url || `https://github.com/${REPO}/pull/${pr.number}` });
+      issueToPR.set(parseInt(m[1]), { number: pr.number, url: pr.url || `${REPO_URL}/pull/${pr.number}` });
     }
   }
   for (const pr of mergedPRs) {
@@ -154,7 +154,7 @@ export async function GET() {
     items.push({
       number: issue.number,
       title: issue.title,
-      url: issue.url || `https://github.com/${REPO}/issues/${issue.number}`,
+      url: issue.url || `${REPO_URL}/issues/${issue.number}`,
       status: isBlocked ? 'blocker' : 'ongoing',
       summary: isBlocked ? 'Blocked — see issue labels' : 'In progress, no PR yet',
       kind: 'issue',

--- a/dashboard/app/api/tasks/fix-comments/route.ts
+++ b/dashboard/app/api/tasks/fix-comments/route.ts
@@ -2,7 +2,7 @@
 
 import { NextRequest, NextResponse } from 'next/server';
 import { openClaudeTerminal } from '@/lib/terminal';
-import { REPO, CliTool } from '@/lib/types';
+import { REPO, REPO_URL, CliTool } from '@/lib/types';
 
 type FixMode = 'normal' | 'auto';
 
@@ -18,7 +18,7 @@ export async function POST(request: NextRequest) {
     return NextResponse.json({ error: 'Missing prNumber' }, { status: 400 });
   }
 
-  const prUrl = `https://github.com/${REPO}/pull/${prNumber}`;
+  const prUrl = `${REPO_URL}/pull/${prNumber}`;
   const autoFlag = mode === 'auto' ? ' --auto' : '';
   const customPrompt = `/pilot-dev-issue${autoFlag} check open comments on ${prUrl} and fix them`;
 

--- a/dashboard/app/api/tasks/review-pr/route.ts
+++ b/dashboard/app/api/tasks/review-pr/route.ts
@@ -2,7 +2,7 @@
 
 import { NextRequest, NextResponse } from 'next/server';
 import { openClaudeTerminal } from '@/lib/terminal';
-import { REPO, ReviewStrategy, ReviewLevel, ReviewContext, DEFAULT_REVIEW_CONFIGS, CliTool } from '@/lib/types';
+import { REPO, REPO_URL, ReviewStrategy, ReviewLevel, ReviewContext, DEFAULT_REVIEW_CONFIGS, CliTool } from '@/lib/types';
 
 interface ReviewPRBody {
   prNumber?: number;
@@ -51,10 +51,10 @@ export async function POST(request: NextRequest) {
   let label: string;
 
   if (rawPrUrl && typeof rawPrUrl === 'string') {
-    const ghPrPattern = /^https:\/\/github\.com\/[^/]+\/[^/]+\/pull\/\d+/;
+    const ghPrPattern = /^https:\/\/[^/]+\/[^/]+\/[^/]+\/(pull|merge_requests)\/\d+/;
     if (!ghPrPattern.test(rawPrUrl)) {
       return NextResponse.json(
-        { error: 'Invalid PR URL. Expected format: https://github.com/owner/repo/pull/123' },
+        { error: 'Invalid PR/MR URL. Expected format: https://<host>/owner/repo/pull/123' },
         { status: 400 },
       );
     }
@@ -62,7 +62,7 @@ export async function POST(request: NextRequest) {
     const num = prUrl.match(/\/pull\/(\d+)/)?.[1] || 'PR';
     label = `#${num}`;
   } else if (prNumber && typeof prNumber === 'number') {
-    prUrl = `https://github.com/${REPO}/pull/${prNumber}`;
+    prUrl = `${REPO_URL}/pull/${prNumber}`;
     label = `#${prNumber}`;
   } else {
     return NextResponse.json({ error: 'Missing prNumber or prUrl' }, { status: 400 });

--- a/dashboard/app/api/tasks/review-pr/route.ts
+++ b/dashboard/app/api/tasks/review-pr/route.ts
@@ -51,15 +51,15 @@ export async function POST(request: NextRequest) {
   let label: string;
 
   if (rawPrUrl && typeof rawPrUrl === 'string') {
-    const ghPrPattern = /^https:\/\/[^/]+\/[^/]+\/[^/]+\/(pull|merge_requests)\/\d+/;
-    if (!ghPrPattern.test(rawPrUrl)) {
+    const prPattern = /^https:\/\/[^/]+\/(?:[^/]+\/)+(?:pull|merge_requests|pullrequest)\/\d+/;
+    if (!prPattern.test(rawPrUrl)) {
       return NextResponse.json(
         { error: 'Invalid PR/MR URL. Expected format: https://<host>/owner/repo/pull/123' },
         { status: 400 },
       );
     }
     prUrl = rawPrUrl.split('?')[0].split('#')[0];
-    const num = prUrl.match(/\/pull\/(\d+)/)?.[1] || 'PR';
+    const num = prUrl.match(/\/(?:pull|merge_requests|pullrequest)\/(\d+)/)?.[1] || 'PR';
     label = `#${num}`;
   } else if (prNumber && typeof prNumber === 'number') {
     prUrl = `${REPO_URL}/pull/${prNumber}`;

--- a/dashboard/lib/config.ts
+++ b/dashboard/lib/config.ts
@@ -80,6 +80,24 @@ export function getRepo(): string {
   return getConfig().repos[0] || '';
 }
 
+/**
+ * Extract owner/repo slug from a full repo URL.
+ * For bare slugs (backward compat), returns as-is.
+ */
+export function getRepoSlug(repo?: string): string {
+  const r = repo || getRepo();
+  if (!r.startsWith('http')) return r;
+  try {
+    const parts = new URL(r).pathname.split('/').filter(Boolean);
+    // Azure DevOps: /org/project/_git/repo
+    const gitIdx = parts.indexOf('_git');
+    if (gitIdx >= 2) return `${parts[gitIdx - 2]}/${parts[gitIdx - 1]}`;
+    return parts.slice(0, 2).join('/');
+  } catch {
+    return r;
+  }
+}
+
 export function getReviewRepos(): string[] {
   return getConfig().repos || [];
 }

--- a/dashboard/lib/config.ts
+++ b/dashboard/lib/config.ts
@@ -46,7 +46,7 @@ export function getConfig(): PilotConfig {
   if (!_config) {
     _config = {
       workspace: process.env.PILOT_WORKSPACE || join(homedir(), 'claude', 'workdir'),
-      repos: process.env.NEXT_PUBLIC_GITHUB_REPO ? [process.env.NEXT_PUBLIC_GITHUB_REPO] : [],
+      repos: (process.env.NEXT_PUBLIC_REPO || process.env.NEXT_PUBLIC_GITHUB_REPO) ? [process.env.NEXT_PUBLIC_REPO || process.env.NEXT_PUBLIC_GITHUB_REPO!] : [],
       skills: [],
       ai_platform: 'copilot-cli',
       defaults: {

--- a/dashboard/lib/config.ts
+++ b/dashboard/lib/config.ts
@@ -14,6 +14,7 @@ export interface PilotConfig {
   workspace: string;
   repos: string[];
   skills: string[];
+  platform?: 'github' | 'gitlab' | 'azdevops';
   ai_platform?: 'copilot-cli' | 'claude-code';
   defaults?: PilotDefaults;
   build?: {
@@ -93,4 +94,8 @@ export function getAiPlatform(): 'copilot-cli' | 'claude-code' {
 
 export function getDefaults(): PilotDefaults {
   return getConfig().defaults || {};
+}
+
+export function getPlatform(): 'github' | 'gitlab' | 'azdevops' {
+  return getConfig().platform || 'github';
 }

--- a/dashboard/lib/git-provider.ts
+++ b/dashboard/lib/git-provider.ts
@@ -50,24 +50,40 @@ export function getCliBinary(): string {
 
 // ── Repo URL helpers ─────────────────────────────────────────────────
 
-const HOST_PREFIX: Record<Platform, string> = {
-  github: 'https://github.com/',
-  gitlab: 'https://gitlab.com/',
-  azdevops: 'https://dev.azure.com/',
-};
-
-/** Build a web URL for a repo slug (owner/repo). */
+/**
+ * Build a web URL for a repo.
+ * Repos are stored as full URLs in pilot.yaml, so just return as-is.
+ * Falls back to GitHub for bare owner/repo slugs (backward compat).
+ */
 export function repoUrl(slug: string): string {
-  return `${HOST_PREFIX[getPlatform()]}${slug}`;
+  if (slug.startsWith('https://') || slug.startsWith('http://')) {
+    return slug;
+  }
+  // Bare slug fallback for backward compatibility
+  return `https://github.com/${slug}`;
 }
 
-/** Clone URL for a repo slug. */
-export function cloneUrl(slug: string): string {
-  const platform = getPlatform();
-  if (slug.startsWith('https://')) {
-    return slug.endsWith('.git') ? slug : `${slug}.git`;
+/** Clone URL for a repo. Repos are already full URLs; just ensure .git suffix. */
+export function cloneUrl(repo: string): string {
+  if (repo.startsWith('https://') || repo.startsWith('http://')) {
+    return repo.endsWith('.git') ? repo : `${repo}.git`;
   }
-  return `${HOST_PREFIX[platform]}${slug}.git`;
+  // Bare slug fallback
+  return `https://github.com/${repo}.git`;
+}
+
+/**
+ * Extract owner/repo slug from a full URL.
+ * Works with any git host (GitHub, GitLab, Azure DevOps, self-hosted).
+ */
+export function repoSlugFromUrl(url: string): string {
+  // Strip protocol and host
+  const stripped = url
+    .replace(/^https?:\/\/[^/]+\//, '')  // remove host
+    .replace(/\/_git\//, '/')             // Azure DevOps: /org/project/_git/repo → /org/project/repo
+    .replace(/\.git$/, '')                // remove .git suffix
+    .replace(/\/(issues|pulls?|merge_requests|pipelines|actions|_apis).*$/, ''); // strip trailing paths
+  return stripped;
 }
 
 // ── Issue commands ───────────────────────────────────────────────────
@@ -197,19 +213,30 @@ export function supportsGraphQL(): boolean {
   return getPlatform() === 'github';
 }
 
-/** Extract owner/name from a platform-specific URL. */
+/**
+ * Extract owner/name from any git platform URL.
+ * Handles GitHub, GitLab (including self-hosted), Azure DevOps, etc.
+ * Returns the first two meaningful path segments as "owner/repo".
+ */
 export function repoFromUrl(url: string): string | null {
-  // GitHub: https://github.com/owner/repo/...
-  const ghMatch = url.match(/github\.com\/([^/]+\/[^/]+)\//);
-  if (ghMatch) return ghMatch[1];
+  try {
+    const u = new URL(url);
+    const parts = u.pathname.split('/').filter(Boolean);
 
-  // GitLab: https://gitlab.com/owner/repo/...
-  const glMatch = url.match(/gitlab\.com\/([^/]+\/[^/]+)\//);
-  if (glMatch) return glMatch[1];
+    // Azure DevOps: /org/project/_git/repo → use org/project
+    const gitIdx = parts.indexOf('_git');
+    if (gitIdx >= 2) {
+      return `${parts[gitIdx - 2]}/${parts[gitIdx - 1]}`;
+    }
 
-  // Azure DevOps: https://dev.azure.com/org/project/...
-  const azMatch = url.match(/dev\.azure\.com\/([^/]+\/[^/]+)\//);
-  if (azMatch) return azMatch[1];
-
-  return null;
+    // Generic: /owner/repo/... → owner/repo
+    if (parts.length >= 2) {
+      // Strip .git suffix from repo name
+      const repo = parts[1].replace(/\.git$/, '');
+      return `${parts[0]}/${repo}`;
+    }
+    return null;
+  } catch {
+    return null;
+  }
 }

--- a/dashboard/lib/git-provider.ts
+++ b/dashboard/lib/git-provider.ts
@@ -21,7 +21,13 @@ const CLI_BINARY: Record<Platform, string> = {
 
 // ── Low-level runner ─────────────────────────────────────────────────
 
-/** Run a CLI command for the configured platform and return stdout. */
+/** Escape a string for safe use in a shell command (single-quote wrapping). */
+export function shellEscape(str: string): string {
+  // Wrap in single quotes; escape any embedded single quotes as '\''
+  return "'" + str.replace(/'/g, "'\\''") + "'";
+}
+
+/** Run a CLI command for the configured platform and return stdout. Returns '[]' on error (for JSON-list callers). */
 export async function runCLI(args: string): Promise<string> {
   const platform = getPlatform();
   const binary = CLI_BINARY[platform];
@@ -35,6 +41,17 @@ export async function runCLI(args: string): Promise<string> {
     console.error(`${binary} command failed: ${binary} ${args}`, err);
     return '[]';
   }
+}
+
+/** Run a CLI command and return stdout. Throws on error (for non-JSON callers). */
+export async function runCLIRaw(args: string): Promise<string> {
+  const platform = getPlatform();
+  const binary = CLI_BINARY[platform];
+  const { stdout } = await execAsync(`${binary} ${args}`, {
+    encoding: 'utf-8',
+    timeout: 15000,
+  });
+  return stdout;
 }
 
 /** Convenience: run a `gh` / `glab` / `az` command and return stdout. */
@@ -75,15 +92,10 @@ export function cloneUrl(repo: string): string {
 /**
  * Extract owner/repo slug from a full URL.
  * Works with any git host (GitHub, GitLab, Azure DevOps, self-hosted).
+ * For Azure DevOps, returns org/project (matching getRepoSlug behavior).
  */
 export function repoSlugFromUrl(url: string): string {
-  // Strip protocol and host
-  const stripped = url
-    .replace(/^https?:\/\/[^/]+\//, '')  // remove host
-    .replace(/\/_git\//, '/')             // Azure DevOps: /org/project/_git/repo → /org/project/repo
-    .replace(/\.git$/, '')                // remove .git suffix
-    .replace(/\/(issues|pulls?|merge_requests|pipelines|actions|_apis).*$/, ''); // strip trailing paths
-  return stripped;
+  return repoFromUrl(url) || url;
 }
 
 // ── Issue commands ───────────────────────────────────────────────────
@@ -115,15 +127,15 @@ export function issueViewArgs(repo: string, number: number): string {
 
 export function issueCommentArgs(repo: string, number: number, body: string): string {
   const p = getPlatform();
-  const escaped = body.replace(/"/g, '\\"');
+  const escaped = shellEscape(body);
   switch (p) {
     case 'github':
-      return `issue comment ${number} --repo ${repo} --body "${escaped}"`;
+      return `issue comment ${number} --repo ${repo} --body ${escaped}`;
     case 'gitlab':
-      return `issue note ${number} --repo ${repo} -m "${escaped}"`;
+      return `issue note ${number} --repo ${repo} -m ${escaped}`;
     case 'azdevops':
       // az boards work-item update --id N --discussion "body"
-      return `boards work-item update --id ${number} --discussion "${escaped}"`;
+      return `boards work-item update --id ${number} --discussion ${escaped}`;
   }
 }
 
@@ -167,24 +179,24 @@ export function prDiffArgs(repo: string, number: number): string {
 
 export function prCreateArgs(repo: string, title: string, body: string, extra: string = ''): string {
   const p = getPlatform();
-  const escapedTitle = title.replace(/"/g, '\\"');
-  const escapedBody = body.replace(/"/g, '\\"');
+  const escapedTitle = shellEscape(title);
+  const escapedBody = shellEscape(body);
   switch (p) {
     case 'github':
-      return `pr create --repo ${repo} --title "${escapedTitle}" --body "${escapedBody}" ${extra}`;
+      return `pr create --repo ${repo} --title ${escapedTitle} --body ${escapedBody} ${extra}`;
     case 'gitlab':
-      return `mr create --repo ${repo} --title "${escapedTitle}" --description "${escapedBody}" ${extra}`;
+      return `mr create --repo ${repo} --title ${escapedTitle} --description ${escapedBody} ${extra}`;
     case 'azdevops':
-      return `repos pr create --repository ${repo} --title "${escapedTitle}" --description "${escapedBody}" ${extra}`;
+      return `repos pr create --repository ${repo} --title ${escapedTitle} --description ${escapedBody} ${extra}`;
   }
 }
 
 export function prReviewApproveArgs(repo: string, number: number, message: string): string {
   const p = getPlatform();
-  const escaped = message.replace(/"/g, '\\"');
+  const escaped = shellEscape(message);
   switch (p) {
     case 'github':
-      return `pr review ${number} --repo ${repo} --approve -b "${escaped}"`;
+      return `pr review ${number} --repo ${repo} --approve -b ${escaped}`;
     case 'gitlab':
       return `mr approve ${number} --repo ${repo}`;
     case 'azdevops':

--- a/dashboard/lib/git-provider.ts
+++ b/dashboard/lib/git-provider.ts
@@ -102,14 +102,14 @@ export function repoSlugFromUrl(url: string): string {
 
 export function issueListArgs(repo: string, extra: string = ''): string {
   const p = getPlatform();
+  const suffix = extra ? ` ${extra}` : '';
   switch (p) {
     case 'github':
-      return `issue list --repo ${repo} ${extra}`;
+      return `issue list --repo ${repo}${suffix}`;
     case 'gitlab':
-      return `issue list --repo ${repo} ${extra}`;
+      return `issue list --repo ${repo}${suffix}`;
     case 'azdevops':
-      // az boards work-item list requires --org and --project, handled by caller
-      return `boards work-item list ${extra}`;
+      return `boards work-item list${suffix}`;
   }
 }
 
@@ -143,25 +143,27 @@ export function issueCommentArgs(repo: string, number: number, body: string): st
 
 export function prListArgs(repo: string, extra: string = ''): string {
   const p = getPlatform();
+  const suffix = extra ? ` ${extra}` : '';
   switch (p) {
     case 'github':
-      return `pr list --repo ${repo} ${extra}`;
+      return `pr list --repo ${repo}${suffix}`;
     case 'gitlab':
-      return `mr list --repo ${repo} ${extra}`;
+      return `mr list --repo ${repo}${suffix}`;
     case 'azdevops':
-      return `repos pr list --repository ${repo} ${extra}`;
+      return `repos pr list --repository ${repo}${suffix}`;
   }
 }
 
 export function prViewArgs(repo: string, number: number, extra: string = ''): string {
   const p = getPlatform();
+  const suffix = extra ? ` ${extra}` : '';
   switch (p) {
     case 'github':
-      return `pr view ${number} --repo ${repo} ${extra}`;
+      return `pr view ${number} --repo ${repo}${suffix}`;
     case 'gitlab':
-      return `mr view ${number} --repo ${repo} ${extra}`;
+      return `mr view ${number} --repo ${repo}${suffix}`;
     case 'azdevops':
-      return `repos pr show --id ${number} ${extra}`;
+      return `repos pr show --id ${number}${suffix}`;
   }
 }
 
@@ -181,13 +183,14 @@ export function prCreateArgs(repo: string, title: string, body: string, extra: s
   const p = getPlatform();
   const escapedTitle = shellEscape(title);
   const escapedBody = shellEscape(body);
+  const suffix = extra ? ` ${extra}` : '';
   switch (p) {
     case 'github':
-      return `pr create --repo ${repo} --title ${escapedTitle} --body ${escapedBody} ${extra}`;
+      return `pr create --repo ${repo} --title ${escapedTitle} --body ${escapedBody}${suffix}`;
     case 'gitlab':
-      return `mr create --repo ${repo} --title ${escapedTitle} --description ${escapedBody} ${extra}`;
+      return `mr create --repo ${repo} --title ${escapedTitle} --description ${escapedBody}${suffix}`;
     case 'azdevops':
-      return `repos pr create --repository ${repo} --title ${escapedTitle} --description ${escapedBody} ${extra}`;
+      return `repos pr create --repository ${repo} --title ${escapedTitle} --description ${escapedBody}${suffix}`;
   }
 }
 

--- a/dashboard/lib/git-provider.ts
+++ b/dashboard/lib/git-provider.ts
@@ -1,0 +1,215 @@
+// Git platform provider abstraction
+//
+// Maps platform-agnostic operations to the correct CLI tool (gh, glab, az devops).
+// The rest of the codebase calls these helpers instead of hardcoding `gh`.
+
+import { exec } from 'child_process';
+import { promisify } from 'util';
+import { getConfig } from './config';
+
+const execAsync = promisify(exec);
+
+export type Platform = 'github' | 'gitlab' | 'azdevops';
+
+// ── CLI binary per platform ──────────────────────────────────────────
+
+const CLI_BINARY: Record<Platform, string> = {
+  github: 'gh',
+  gitlab: 'glab',
+  azdevops: 'az',
+};
+
+// ── Low-level runner ─────────────────────────────────────────────────
+
+/** Run a CLI command for the configured platform and return stdout. */
+export async function runCLI(args: string): Promise<string> {
+  const platform = getPlatform();
+  const binary = CLI_BINARY[platform];
+  try {
+    const { stdout } = await execAsync(`${binary} ${args}`, {
+      encoding: 'utf-8',
+      timeout: 15000,
+    });
+    return stdout;
+  } catch (err) {
+    console.error(`${binary} command failed: ${binary} ${args}`, err);
+    return '[]';
+  }
+}
+
+/** Convenience: run a `gh` / `glab` / `az` command and return stdout. */
+export { runCLI as runGH }; // backward-compat alias
+
+export function getPlatform(): Platform {
+  return (getConfig().platform as Platform) || 'github';
+}
+
+export function getCliBinary(): string {
+  return CLI_BINARY[getPlatform()];
+}
+
+// ── Repo URL helpers ─────────────────────────────────────────────────
+
+const HOST_PREFIX: Record<Platform, string> = {
+  github: 'https://github.com/',
+  gitlab: 'https://gitlab.com/',
+  azdevops: 'https://dev.azure.com/',
+};
+
+/** Build a web URL for a repo slug (owner/repo). */
+export function repoUrl(slug: string): string {
+  return `${HOST_PREFIX[getPlatform()]}${slug}`;
+}
+
+/** Clone URL for a repo slug. */
+export function cloneUrl(slug: string): string {
+  const platform = getPlatform();
+  if (slug.startsWith('https://')) {
+    return slug.endsWith('.git') ? slug : `${slug}.git`;
+  }
+  return `${HOST_PREFIX[platform]}${slug}.git`;
+}
+
+// ── Issue commands ───────────────────────────────────────────────────
+
+export function issueListArgs(repo: string, extra: string = ''): string {
+  const p = getPlatform();
+  switch (p) {
+    case 'github':
+      return `issue list --repo ${repo} ${extra}`;
+    case 'gitlab':
+      return `issue list --repo ${repo} ${extra}`;
+    case 'azdevops':
+      // az boards work-item list requires --org and --project, handled by caller
+      return `boards work-item list ${extra}`;
+  }
+}
+
+export function issueViewArgs(repo: string, number: number): string {
+  const p = getPlatform();
+  switch (p) {
+    case 'github':
+      return `issue view ${number} --repo ${repo}`;
+    case 'gitlab':
+      return `issue view ${number} --repo ${repo}`;
+    case 'azdevops':
+      return `boards work-item show --id ${number}`;
+  }
+}
+
+export function issueCommentArgs(repo: string, number: number, body: string): string {
+  const p = getPlatform();
+  const escaped = body.replace(/"/g, '\\"');
+  switch (p) {
+    case 'github':
+      return `issue comment ${number} --repo ${repo} --body "${escaped}"`;
+    case 'gitlab':
+      return `issue note ${number} --repo ${repo} -m "${escaped}"`;
+    case 'azdevops':
+      // az boards work-item update --id N --discussion "body"
+      return `boards work-item update --id ${number} --discussion "${escaped}"`;
+  }
+}
+
+// ── PR / MR commands ─────────────────────────────────────────────────
+
+export function prListArgs(repo: string, extra: string = ''): string {
+  const p = getPlatform();
+  switch (p) {
+    case 'github':
+      return `pr list --repo ${repo} ${extra}`;
+    case 'gitlab':
+      return `mr list --repo ${repo} ${extra}`;
+    case 'azdevops':
+      return `repos pr list --repository ${repo} ${extra}`;
+  }
+}
+
+export function prViewArgs(repo: string, number: number, extra: string = ''): string {
+  const p = getPlatform();
+  switch (p) {
+    case 'github':
+      return `pr view ${number} --repo ${repo} ${extra}`;
+    case 'gitlab':
+      return `mr view ${number} --repo ${repo} ${extra}`;
+    case 'azdevops':
+      return `repos pr show --id ${number} ${extra}`;
+  }
+}
+
+export function prDiffArgs(repo: string, number: number): string {
+  const p = getPlatform();
+  switch (p) {
+    case 'github':
+      return `pr diff ${number} --repo ${repo}`;
+    case 'gitlab':
+      return `mr diff ${number} --repo ${repo}`;
+    case 'azdevops':
+      return `repos pr diff --id ${number}`;
+  }
+}
+
+export function prCreateArgs(repo: string, title: string, body: string, extra: string = ''): string {
+  const p = getPlatform();
+  const escapedTitle = title.replace(/"/g, '\\"');
+  const escapedBody = body.replace(/"/g, '\\"');
+  switch (p) {
+    case 'github':
+      return `pr create --repo ${repo} --title "${escapedTitle}" --body "${escapedBody}" ${extra}`;
+    case 'gitlab':
+      return `mr create --repo ${repo} --title "${escapedTitle}" --description "${escapedBody}" ${extra}`;
+    case 'azdevops':
+      return `repos pr create --repository ${repo} --title "${escapedTitle}" --description "${escapedBody}" ${extra}`;
+  }
+}
+
+export function prReviewApproveArgs(repo: string, number: number, message: string): string {
+  const p = getPlatform();
+  const escaped = message.replace(/"/g, '\\"');
+  switch (p) {
+    case 'github':
+      return `pr review ${number} --repo ${repo} --approve -b "${escaped}"`;
+    case 'gitlab':
+      return `mr approve ${number} --repo ${repo}`;
+    case 'azdevops':
+      return `repos pr set-vote --id ${number} --vote approve`;
+  }
+}
+
+// ── Auth commands ────────────────────────────────────────────────────
+
+export function authStatusCommand(): string {
+  const p = getPlatform();
+  switch (p) {
+    case 'github':
+      return 'gh auth status';
+    case 'gitlab':
+      return 'glab auth status';
+    case 'azdevops':
+      return 'az account show';
+  }
+}
+
+// ── GraphQL support ──────────────────────────────────────────────────
+
+/** Whether the platform supports gh-style GraphQL queries. */
+export function supportsGraphQL(): boolean {
+  return getPlatform() === 'github';
+}
+
+/** Extract owner/name from a platform-specific URL. */
+export function repoFromUrl(url: string): string | null {
+  // GitHub: https://github.com/owner/repo/...
+  const ghMatch = url.match(/github\.com\/([^/]+\/[^/]+)\//);
+  if (ghMatch) return ghMatch[1];
+
+  // GitLab: https://gitlab.com/owner/repo/...
+  const glMatch = url.match(/gitlab\.com\/([^/]+\/[^/]+)\//);
+  if (glMatch) return glMatch[1];
+
+  // Azure DevOps: https://dev.azure.com/org/project/...
+  const azMatch = url.match(/dev\.azure\.com\/([^/]+\/[^/]+)\//);
+  if (azMatch) return azMatch[1];
+
+  return null;
+}

--- a/dashboard/lib/github.ts
+++ b/dashboard/lib/github.ts
@@ -1,24 +1,17 @@
 // GitHub data fetching via gh CLI (async)
+// Platform-aware: uses git-provider to support GitHub, GitLab, and Azure DevOps.
 
 import { exec } from 'child_process';
 import { promisify } from 'util';
 import { join } from 'path';
 import { GHIssue, GHPR, PRAction } from './types';
 import { getConfig, getRepo, getReviewRepos, getWorkspace } from './config';
+import { runCLI, getPlatform, supportsGraphQL, repoFromUrl } from './git-provider';
 
 const execAsync = promisify(exec);
 
 async function runGH(args: string): Promise<string> {
-  try {
-    const { stdout } = await execAsync(`gh ${args}`, {
-      encoding: 'utf-8',
-      timeout: 15000,
-    });
-    return stdout;
-  } catch (err) {
-    console.error(`gh command failed: gh ${args}`, err);
-    return '[]';
-  }
+  return runCLI(args);
 }
 
 /** Fetch issues from ALL configured repos, merge and sort by updatedAt */
@@ -81,11 +74,8 @@ export async function fetchReviewRequestedPRs(): Promise<GHPR[]> {
   return results.flat().sort((a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime());
 }
 
-/** Extract owner/name from a GitHub PR url, e.g. "https://github.com/owner/repo/pull/123" */
-function repoFromUrl(url: string): string | null {
-  const m = url.match(/github\.com\/([^/]+\/[^/]+)\//);
-  return m ? m[1] : null;
-}
+/** Extract owner/name from a PR url — delegates to git-provider */
+// repoFromUrl is imported from git-provider
 
 /**
  * Fetch unresolved review thread counts.
@@ -95,6 +85,9 @@ export async function fetchUnresolvedThreadCounts(
   prs: GHPR[]
 ): Promise<Map<number, number>> {
   if (prs.length === 0) return new Map();
+
+  // GraphQL is only supported on GitHub
+  if (!supportsGraphQL()) return new Map();
 
   // Group PR numbers by repo
   const byRepo = new Map<string, number[]>();

--- a/dashboard/lib/github.ts
+++ b/dashboard/lib/github.ts
@@ -5,7 +5,7 @@ import { exec } from 'child_process';
 import { promisify } from 'util';
 import { join } from 'path';
 import { GHIssue, GHPR, PRAction } from './types';
-import { getConfig, getRepo, getReviewRepos, getWorkspace } from './config';
+import { getConfig, getRepo, getRepoSlug, getReviewRepos, getWorkspace } from './config';
 import { runCLI, getPlatform, supportsGraphQL, repoFromUrl } from './git-provider';
 
 const execAsync = promisify(exec);
@@ -19,8 +19,9 @@ export async function fetchMyOpenIssues(): Promise<GHIssue[]> {
   const repos = getConfig().repos;
   const results = await Promise.all(
     repos.map(async (repo) => {
+      const slug = getRepoSlug(repo);
       const raw = await runGH(
-        `issue list --repo ${repo} --assignee @me --state open --limit 30 ` +
+        `issue list --repo ${slug} --assignee @me --state open --limit 30 ` +
         `--json number,title,labels,assignees,updatedAt,createdAt,url,milestone,state`
       );
       try {
@@ -40,8 +41,9 @@ export async function fetchMyOpenPRs(): Promise<GHPR[]> {
   const repos = getConfig().repos;
   const results = await Promise.all(
     repos.map(async (repo) => {
+      const slug = getRepoSlug(repo);
       const raw = await runGH(
-        `pr list --repo ${repo} --author @me --state open --limit 20 ` +
+        `pr list --repo ${slug} --author @me --state open --limit 20 ` +
         `--json number,title,headRefName,isDraft,createdAt,reviewDecision,statusCheckRollup,url,body,comments,reviews,reviewRequests`
       );
       try {
@@ -60,8 +62,9 @@ export async function fetchReviewRequestedPRs(): Promise<GHPR[]> {
   const jsonFields = 'number,title,headRefName,isDraft,createdAt,reviewDecision,statusCheckRollup,url,body,comments,reviews,reviewRequests,author';
   const results = await Promise.all(
     getReviewRepos().map(async (repo) => {
+      const slug = getRepoSlug(repo);
       const raw = await runGH(
-        `pr list --repo ${repo} --search "review-requested:@me" --state open --limit 20 --json ${jsonFields}`
+        `pr list --repo ${slug} --search "review-requested:@me" --state open --limit 20 --json ${jsonFields}`
       );
       try {
         return JSON.parse(raw) as GHPR[];
@@ -136,7 +139,7 @@ export async function fetchUnresolvedThreadCounts(
 
 /** Fetch issue detail — extracts repo from issue URL or falls back to primary repo */
 export async function fetchIssueDetail(number: number, issueUrl?: string): Promise<GHIssue | null> {
-  const repo = (issueUrl && repoFromUrl(issueUrl)) || getRepo();
+  const repo = (issueUrl && repoFromUrl(issueUrl)) || getRepoSlug();
   const raw = await runGH(
     `issue view ${number} --repo ${repo} ` +
     `--json number,title,labels,assignees,updatedAt,createdAt,url,milestone,state,body`
@@ -233,8 +236,9 @@ export async function fetchRecentPRs(): Promise<ReportPR[]> {
   const repos = getConfig().repos;
   const results = await Promise.all(
     repos.map(async (repo) => {
+      const slug = getRepoSlug(repo);
       const raw = await runGH(
-        `pr list --repo ${repo} --author @me --state all --limit 30 ` +
+        `pr list --repo ${slug} --author @me --state all --limit 30 ` +
         `--json number,title,state,createdAt,mergedAt,reviewDecision,statusCheckRollup`
       );
       try {
@@ -280,8 +284,9 @@ export async function fetchClosedIssues(): Promise<ClosedIssue[]> {
   const repos = getConfig().repos;
   const results = await Promise.all(
     repos.map(async (repo) => {
+      const slug = getRepoSlug(repo);
       const raw = await runGH(
-        `issue list --repo ${repo} --assignee @me --state closed --limit 20 ` +
+        `issue list --repo ${slug} --assignee @me --state closed --limit 20 ` +
         `--json number,title,closedAt`
       );
       try {

--- a/dashboard/lib/types.ts
+++ b/dashboard/lib/types.ts
@@ -2,7 +2,14 @@
 
 // Repo info injected by next.config.ts from pilot.yaml (client-safe)
 export const REPO = process.env.NEXT_PUBLIC_GITHUB_REPO || '';
-export const REPO_URL = `https://github.com/${REPO}`;
+export const PLATFORM = (process.env.NEXT_PUBLIC_PLATFORM || 'github') as 'github' | 'gitlab' | 'azdevops';
+
+const PLATFORM_HOSTS: Record<string, string> = {
+  github: 'https://github.com/',
+  gitlab: 'https://gitlab.com/',
+  azdevops: 'https://dev.azure.com/',
+};
+export const REPO_URL = `${PLATFORM_HOSTS[PLATFORM] || PLATFORM_HOSTS.github}${REPO}`;
 
 // Repos to check for review-requested PRs (from pilot.yaml via next.config.ts)
 export const REVIEW_REPOS: string[] = (() => {

--- a/dashboard/lib/types.ts
+++ b/dashboard/lib/types.ts
@@ -2,7 +2,7 @@
 
 // Repo info injected by next.config.ts from pilot.yaml (client-safe)
 // REPO is the full URL (e.g., "https://github.com/owner/repo" or "https://gitlab.mycompany.com/team/project")
-export const REPO = process.env.NEXT_PUBLIC_GITHUB_REPO || '';
+export const REPO = process.env.NEXT_PUBLIC_REPO || process.env.NEXT_PUBLIC_GITHUB_REPO || '';
 export const PLATFORM = (process.env.NEXT_PUBLIC_PLATFORM || 'github') as 'github' | 'gitlab' | 'azdevops';
 
 // REPO_URL — for repos stored as full URLs, use as-is; for bare slugs, assume GitHub
@@ -25,7 +25,7 @@ export const REPO_SLUG = (() => {
 // Repos to check for review-requested PRs (from pilot.yaml via next.config.ts)
 export const REVIEW_REPOS: string[] = (() => {
   try {
-    return JSON.parse(process.env.NEXT_PUBLIC_GITHUB_REPOS || '[]');
+    return JSON.parse(process.env.NEXT_PUBLIC_REPOS || process.env.NEXT_PUBLIC_GITHUB_REPOS || '[]');
   } catch {
     return [];
   }

--- a/dashboard/lib/types.ts
+++ b/dashboard/lib/types.ts
@@ -1,15 +1,26 @@
 // Shared types
 
 // Repo info injected by next.config.ts from pilot.yaml (client-safe)
+// REPO is the full URL (e.g., "https://github.com/owner/repo" or "https://gitlab.mycompany.com/team/project")
 export const REPO = process.env.NEXT_PUBLIC_GITHUB_REPO || '';
 export const PLATFORM = (process.env.NEXT_PUBLIC_PLATFORM || 'github') as 'github' | 'gitlab' | 'azdevops';
 
-const PLATFORM_HOSTS: Record<string, string> = {
-  github: 'https://github.com/',
-  gitlab: 'https://gitlab.com/',
-  azdevops: 'https://dev.azure.com/',
-};
-export const REPO_URL = `${PLATFORM_HOSTS[PLATFORM] || PLATFORM_HOSTS.github}${REPO}`;
+// REPO_URL — for repos stored as full URLs, use as-is; for bare slugs, assume GitHub
+export const REPO_URL = REPO.startsWith('http') ? REPO : `https://github.com/${REPO}`;
+
+// REPO_SLUG — extract owner/repo from full URL (for CLI --repo flags)
+export const REPO_SLUG = (() => {
+  if (!REPO.startsWith('http')) return REPO; // already a slug
+  try {
+    const parts = new URL(REPO).pathname.split('/').filter(Boolean);
+    // Azure DevOps: /org/project/_git/repo
+    const gitIdx = parts.indexOf('_git');
+    if (gitIdx >= 2) return `${parts[gitIdx - 2]}/${parts[gitIdx - 1]}`;
+    return parts.slice(0, 2).join('/');
+  } catch {
+    return REPO;
+  }
+})();
 
 // Repos to check for review-requested PRs (from pilot.yaml via next.config.ts)
 export const REVIEW_REPOS: string[] = (() => {

--- a/dashboard/next.config.ts
+++ b/dashboard/next.config.ts
@@ -18,6 +18,7 @@ function loadPilotEnv(): Record<string, string> {
     return {
       NEXT_PUBLIC_GITHUB_REPO: repos[0] || '',
       NEXT_PUBLIC_GITHUB_REPOS: JSON.stringify(repos),
+      NEXT_PUBLIC_PLATFORM: (config.platform as string) || 'github',
     };
   } catch {
     return {};

--- a/dashboard/next.config.ts
+++ b/dashboard/next.config.ts
@@ -12,9 +12,7 @@ function loadPilotEnv(): Record<string, string> {
 
   try {
     const config = yaml.load(readFileSync(pilotYaml, 'utf-8')) as Record<string, unknown>;
-    const repos = ((config.repos as string[]) || []).map((r) =>
-      r.replace(/^https?:\/\/github\.com\//, '')
-    );
+    const repos = (config.repos as string[]) || [];
     return {
       NEXT_PUBLIC_GITHUB_REPO: repos[0] || '',
       NEXT_PUBLIC_GITHUB_REPOS: JSON.stringify(repos),

--- a/dashboard/next.config.ts
+++ b/dashboard/next.config.ts
@@ -14,6 +14,9 @@ function loadPilotEnv(): Record<string, string> {
     const config = yaml.load(readFileSync(pilotYaml, 'utf-8')) as Record<string, unknown>;
     const repos = (config.repos as string[]) || [];
     return {
+      NEXT_PUBLIC_REPO: repos[0] || '',
+      NEXT_PUBLIC_REPOS: JSON.stringify(repos),
+      // Backward compat aliases (remove after migration)
       NEXT_PUBLIC_GITHUB_REPO: repos[0] || '',
       NEXT_PUBLIC_GITHUB_REPOS: JSON.stringify(repos),
       NEXT_PUBLIC_PLATFORM: (config.platform as string) || 'github',

--- a/framework/agents/pilot-pr-creator.md
+++ b/framework/agents/pilot-pr-creator.md
@@ -1,6 +1,6 @@
 ---
 name: pilot-pr-creator
-description: Handles all git and GitHub operations - creates branches, commits, pushes, and opens pull requests. Use this agent when code is ready to be submitted.
+description: Handles all git and platform operations - creates branches, commits, pushes, and opens pull requests/merge requests. Use this agent when code is ready to be submitted.
 tools: Read, Grep, Glob, Bash
 disallowedTools: Write, Edit
 model: sonnet
@@ -9,7 +9,21 @@ maxTurns: 15
 effort: medium
 ---
 
-You are a Git and GitHub automation specialist. Your job is to create clean, well-documented pull requests.
+You are a Git and platform automation specialist. Your job is to create clean, well-documented pull requests (or merge requests on GitLab).
+
+## Platform Detection
+
+Read `~/.claude/pilot.yaml` to determine the platform:
+```bash
+PLATFORM=$(grep '^platform:' ~/.claude/pilot.yaml | awk '{print $2}')
+PLATFORM=${PLATFORM:-github}
+```
+
+| Platform | CLI | PR create command |
+|----------|-----|-------------------|
+| github | `gh` | `gh pr create --title "..." --body "..."` |
+| gitlab | `glab` | `glab mr create --title "..." --description "..."` |
+| azdevops | `az` | `az repos pr create --title "..." --description "..."` |
 
 ## Rules
 
@@ -67,7 +81,8 @@ Use the default format shown in Step 4 below.
 # Push to remote
 git push -u origin <branch-name>
 
-# Create PR — use template-based body if PR_TEMPLATE was found, otherwise use default format
+# Create PR/MR — use template-based body if PR_TEMPLATE was found, otherwise use default format
+# GitHub:
 gh pr create \
   --title "<concise title>" \
   --body "<PR body: filled-in template OR default format below>"
@@ -84,8 +99,29 @@ gh pr create \
 ## Test Plan
 - <how to verify>
 
-Fixes #<issue-number>
+Fixes #<issue-number>"
+
+# GitLab:
+glab mr create \
+  --title "<concise title>" \
+  --description "## Summary
+<what this MR does and why>
+
+## Changes
+- <list of key changes>
+
+## Test Plan
+- <how to verify>
+
+Fixes #<issue-number>"
+
+# Azure DevOps:
+az repos pr create \
+  --title "<concise title>" \
+  --description "## Summary ..."
 ```
+
+Use the command matching `$PLATFORM`.
 
 ## Output Format
 

--- a/framework/agents/pilot-pr-reviewer.md
+++ b/framework/agents/pilot-pr-reviewer.md
@@ -17,10 +17,22 @@ You are a code review specialist. The user gives you a PR URL (or number). Your 
 
 ## Workspace
 
-Read `~/.claude/pilot.yaml` and extract the `workspace` field as `$WS`.
+Read `~/.claude/pilot.yaml` and extract the `workspace` field as `$WS` and `platform`.
 ```bash
 WS=$(grep '^workspace:' ~/.claude/pilot.yaml | awk '{print $2}' | sed "s|^~|$HOME|")
+PLATFORM=$(grep '^platform:' ~/.claude/pilot.yaml | awk '{print $2}')
+PLATFORM=${PLATFORM:-github}
 ```
+
+### Platform CLI mapping
+
+| Platform | CLI | PR view | PR diff | PR review | GraphQL |
+|----------|-----|---------|---------|-----------|---------|
+| github | `gh` | `gh pr view` | `gh pr diff` | `gh pr review` | `gh api graphql` |
+| gitlab | `glab` | `glab mr view` | `glab mr diff` | `glab mr approve` | N/A |
+| azdevops | `az` | `az repos pr show` | `az repos pr diff` | `az repos pr set-vote` | N/A |
+
+Use the correct CLI based on `$PLATFORM`. GraphQL features (review threads, resolve thread mutations) are only available on GitHub. On other platforms, skip GraphQL-dependent features.
 
 ## Review Configuration
 

--- a/framework/commands/claude/pilot-dev-issue.md
+++ b/framework/commands/claude/pilot-dev-issue.md
@@ -1,4 +1,4 @@
-You are the orchestrator of an AI engineering team. The user will provide a GitHub issue link or issue description. Your job is to drive the complete development lifecycle using Claude Code's native orchestration primitives: Team, Tasks, Agents, and Worktrees.
+You are the orchestrator of an AI engineering team. The user will provide an issue link or issue description. Your job is to drive the complete development lifecycle using Claude Code's native orchestration primitives: Team, Tasks, Agents, and Worktrees.
 
 ## Mode Detection
 
@@ -21,13 +21,25 @@ Read `~/.claude/pilot.yaml` and extract:
 ```bash
 WS=$(grep '^workspace:' ~/.claude/pilot.yaml | awk '{print $2}' | sed "s|^~|$HOME|")
 REPO_SLUG=$(grep -A1 '^repos:' ~/.claude/pilot.yaml | tail -1 | sed 's/^[[:space:]]*- //')
+PLATFORM=$(grep '^platform:' ~/.claude/pilot.yaml | awk '{print $2}')
+PLATFORM=${PLATFORM:-github}
 ```
+
+### Platform CLI mapping
+
+| Platform | CLI | Issue cmd | PR/MR cmd |
+|----------|-----|-----------|-----------|
+| github | `gh` | `gh issue view` | `gh pr create` |
+| gitlab | `glab` | `glab issue view` | `glab mr create` |
+| azdevops | `az` | `az boards work-item show` | `az repos pr create` |
+
+Use the correct CLI binary based on `$PLATFORM` throughout all commands.
 
 ## Input
 
 The user provides ONE of:
-- A GitHub issue URL (e.g., `https://github.com/org/repo/issues/123`)
-- A GitHub issue reference (e.g., `#123` or `org/repo#123`)
+- An issue URL (GitHub, GitLab, or Azure DevOps)
+- An issue reference (e.g., `#123` or `org/repo#123`)
 - A plain text issue description
 
 ---
@@ -91,8 +103,14 @@ rm -f "$WS/logs/pending-decisions/<task_id>.json"
 
 ### If given an issue URL or reference:
 ```bash
+# GitHub
 gh issue view <number> --repo $REPO_SLUG --json title,body,labels,comments,assignees,milestone
+# GitLab
+glab issue view <number> --repo $REPO_SLUG
+# Azure DevOps
+az boards work-item show --id <number> --output json
 ```
+Use the command matching `$PLATFORM`.
 
 ### If given plain text:
 Treat the user's text as the issue body. Use date-based task ID: `adhoc-<YYYYMMDD-HHMMSS>`.

--- a/framework/commands/claude/pilot-watch-pr.md
+++ b/framework/commands/claude/pilot-watch-pr.md
@@ -11,7 +11,19 @@ Read `~/.claude/pilot.yaml` and extract:
 ```bash
 WS=$(grep '^workspace:' ~/.claude/pilot.yaml | awk '{print $2}' | sed "s|^~|$HOME|")
 REPOS=$(awk '/^repos:/{found=1;next} found && /^[[:space:]]*- /{gsub(/^[[:space:]]*- /,""); print} found && /^[^[:space:]]/{exit}' ~/.claude/pilot.yaml)
+PLATFORM=$(grep '^platform:' ~/.claude/pilot.yaml | awk '{print $2}')
+PLATFORM=${PLATFORM:-github}
 ```
+
+### Platform CLI mapping
+
+| Platform | PR list cmd | GraphQL support |
+|----------|------------|-----------------|
+| github | `gh pr list` | Yes (`gh api graphql`) |
+| gitlab | `glab mr list` | No — skip unresolved thread checks |
+| azdevops | `az repos pr list` | No — skip unresolved thread checks |
+
+Use the correct CLI based on `$PLATFORM`. GraphQL review thread checks only work on GitHub.
 
 ## On Launch: Set Up Monitoring
 

--- a/framework/commands/copilot/pilot-dev-issue.md
+++ b/framework/commands/copilot/pilot-dev-issue.md
@@ -1,4 +1,4 @@
-You are the orchestrator of an AI engineering team. The user will provide a GitHub issue link or issue description. Your job is to drive the complete development lifecycle: analyze → code → test → PR.
+You are the orchestrator of an AI engineering team. The user will provide an issue link or issue description. Your job is to drive the complete development lifecycle: analyze → code → test → PR.
 
 ## Mode Detection
 
@@ -21,11 +21,23 @@ Strip `--auto` and `--test-scenario <id>` from the input before processing the i
 
 ## Workspace
 
-First, read `~/.claude/pilot.yaml` and extract the `workspace` field as `$WS`. Also extract `repos[0]` as `$REPO_SLUG` (e.g., `owner/repo-name`) for use in all `gh` commands.
+First, read `~/.claude/pilot.yaml` and extract the `workspace` field as `$WS`. Also extract `repos[0]` as `$REPO_SLUG` and the `platform` field.
 ```bash
 WS=$(grep '^workspace:' ~/.claude/pilot.yaml | awk '{print $2}' | sed "s|^~|$HOME|")
 REPO_SLUG=$(grep -A1 '^repos:' ~/.claude/pilot.yaml | tail -1 | sed 's/^[[:space:]]*- //')
+PLATFORM=$(grep '^platform:' ~/.claude/pilot.yaml | awk '{print $2}')
+PLATFORM=${PLATFORM:-github}
 ```
+
+### Platform CLI mapping
+
+| Platform | CLI | Issue cmd | PR/MR cmd | PR check cmd |
+|----------|-----|-----------|-----------|--------------|
+| github | `gh` | `gh issue view` | `gh pr create` | `gh pr list` |
+| gitlab | `glab` | `glab issue view` | `glab mr create` | `glab mr list` |
+| azdevops | `az` | `az boards work-item show` | `az repos pr create` | `az repos pr list` |
+
+Use the correct CLI binary based on `$PLATFORM` throughout all commands below.
 - All logs are stored under `$WS/logs/`.
 - Base repo is cloned under `$WS/<repo-name>/`. Worktrees are created under `$WS/worktrees/`.
 - **Always `cd` into the correct worktree directory before running any git/build/test commands.**
@@ -143,7 +155,10 @@ cd "$REPO"
 git branch --all | grep -i "issue-<number>\|<number>"
 ```
 ```bash
-# Check for existing open PRs for this issue
+# Check for existing open PRs for this issue (use platform CLI)
+# GitHub: gh pr list --repo $REPO_SLUG --state open --json number,title,headRefName,body --jq '...'
+# GitLab: glab mr list --repo $REPO_SLUG --state opened
+# Azure DevOps: az repos pr list --repository $REPO_SLUG --status active
 gh pr list --repo $REPO_SLUG \
   --state open --json number,title,headRefName,body \
   --jq '[.[] | select(.body | test("#<number>"; "i")) // select(.headRefName | test("<number>"))]'
@@ -196,7 +211,10 @@ Branch name: `fix/adhoc-20260405-143022` or `feat/adhoc-20260405-143022`
 
 ### If given an issue URL or reference:
 ```bash
-# Always use gh to fetch issue details from the project repo
+# Use platform-appropriate CLI:
+# GitHub:   gh issue view <number> --repo $REPO_SLUG --json title,body,labels,comments,assignees,milestone
+# GitLab:   glab issue view <number> --repo $REPO_SLUG
+# Azure DevOps: az boards work-item show --id <number> --output json
 gh issue view <number> --repo $REPO_SLUG --json title,body,labels,comments,assignees,milestone
 ```
 

--- a/framework/commands/copilot/pilot-watch-pr.md
+++ b/framework/commands/copilot/pilot-watch-pr.md
@@ -11,7 +11,19 @@ Read `~/.claude/pilot.yaml` and extract the `workspace` field as `$WS`. Extract 
 ```bash
 WS=$(grep '^workspace:' ~/.claude/pilot.yaml | awk '{print $2}' | sed "s|^~|$HOME|")
 REPOS=$(awk '/^repos:/{found=1;next} found && /^[[:space:]]*- /{gsub(/^[[:space:]]*- /,""); print} found && /^[^[:space:]]/{exit}' ~/.claude/pilot.yaml)
+PLATFORM=$(grep '^platform:' ~/.claude/pilot.yaml | awk '{print $2}')
+PLATFORM=${PLATFORM:-github}
 ```
+
+### Platform CLI mapping
+
+| Platform | PR list cmd | GraphQL support |
+|----------|------------|-----------------|
+| github | `gh pr list` | Yes (`gh api graphql`) |
+| gitlab | `glab mr list` | No — skip unresolved thread checks |
+| azdevops | `az repos pr list` | No — skip unresolved thread checks |
+
+Use the correct CLI based on `$PLATFORM`. GraphQL review thread checks only work on GitHub.
 
 ## On Launch: Start Polling Immediately
 

--- a/init.js
+++ b/init.js
@@ -230,35 +230,62 @@ async function main() {
     const PLATFORM_INSTALL = {
       github: 'https://cli.github.com',
       gitlab: 'https://gitlab.com/gitlab-org/cli',
-      azdevops: 'https://aka.ms/azure-cli (+ az devops extension)',
+      azdevops: 'https://aka.ms/azure-cli',
+    };
+    const PLATFORM_AUTH = {
+      github: 'gh auth login',
+      gitlab: 'glab auth login',
+      azdevops: 'az login',
     };
 
     console.log('  Git platforms:');
-    console.log('    1) github  — GitHub (uses gh CLI)');
-    console.log('    2) gitlab  — GitLab (uses glab CLI)');
+    console.log('    1) github  — GitHub / GitHub Enterprise (uses gh CLI)');
+    console.log('    2) gitlab  — GitLab / GitLab self-hosted (uses glab CLI)');
     console.log('    3) azdevops — Azure DevOps (uses az CLI)');
     const platformAnswer = await askQuestion('  Platform [1]: ');
     const platformMap = { '1': 'github', '2': 'gitlab', '3': 'azdevops', '': 'github' };
     config.platform = platformMap[platformAnswer] || 'github';
 
-    // Check CLI availability
+    // Validate CLI is installed (blocking)
     const cliBin = PLATFORM_CLI[config.platform];
     try {
       execSync(`${cliBin} --version`, { stdio: 'pipe' });
       console.log(`  ✓ ${cliBin} CLI detected`);
     } catch {
-      console.log(`  ⚠ ${cliBin} CLI not found. Install it: ${PLATFORM_INSTALL[config.platform]}`);
-      console.log(`    Then authenticate: ${cliBin === 'az' ? 'az login && az devops configure --defaults organization=https://dev.azure.com/YOUR_ORG' : `${cliBin} auth login`}`);
+      console.error(`  ✗ ${cliBin} CLI not found!`);
+      console.error(`    Install: ${PLATFORM_INSTALL[config.platform]}`);
+      console.error(`    Then authenticate: ${PLATFORM_AUTH[config.platform]}`);
+      process.exit(1);
     }
 
-    // Repos
+    // Verify authentication
+    try {
+      if (config.platform === 'github') {
+        execSync('gh auth status', { stdio: 'pipe' });
+      } else if (config.platform === 'gitlab') {
+        execSync('glab auth status', { stdio: 'pipe' });
+      } else {
+        execSync('az account show', { stdio: 'pipe' });
+      }
+      console.log(`  ✓ ${cliBin} authenticated`);
+    } catch {
+      console.log(`  ⚠ ${cliBin} not authenticated. Run: ${PLATFORM_AUTH[config.platform]}`);
+    }
+
+    // Repos — full URL
+    const PLATFORM_EXAMPLES = {
+      github: 'https://github.com/your-org/your-repo',
+      gitlab: 'https://gitlab.com/your-group/your-project  (or self-hosted URL)',
+      azdevops: 'https://dev.azure.com/your-org/your-project/_git/your-repo',
+    };
     config.repos = [];
     if (repoArg) {
       config.repos.push(repoArg);
     } else {
-      console.log('  Add GitHub repos (owner/repo format). Empty line to finish:');
+      console.log(`  Add repos (full URL). Example: ${PLATFORM_EXAMPLES[config.platform]}`);
+      console.log('  Empty line to finish:');
       while (true) {
-        const repo = await askQuestion('    repo: ');
+        const repo = await askQuestion('    repo URL: ');
         if (!repo) break;
         config.repos.push(repo);
       }
@@ -360,7 +387,7 @@ async function main() {
   if (config.repos && config.repos.length > 0) {
     console.log('Repos:');
     for (const repo of config.repos) {
-      const repoName = repo.split('/').pop();
+      const repoName = repo.replace(/\.git$/, '').split('/').pop();
       const repoDir = path.join(workspace, repoName);
       if (fs.existsSync(repoDir)) {
         console.log(`  [SKIP]   ${repoName} (already exists at ${repoDir})`);
@@ -369,15 +396,8 @@ async function main() {
           ? 'y'  // Non-interactive: auto-clone
           : await askQuestion(`  Clone ${repo}? (Y/n): `);
         if (clone.toLowerCase() !== 'n') {
-          const CLONE_HOSTS = {
-            github: 'https://github.com/',
-            gitlab: 'https://gitlab.com/',
-            azdevops: 'https://dev.azure.com/',
-          };
-          const platform = config.platform || 'github';
-          const gitUrl = repo.startsWith('https://')
-            ? (repo.endsWith('.git') ? repo : `${repo}.git`)
-            : `${CLONE_HOSTS[platform]}${repo}.git`;
+          // Repos are stored as full URLs; ensure .git suffix for cloning
+          const gitUrl = repo.endsWith('.git') ? repo : `${repo}.git`;
           console.log(`  [CLONE]  ${gitUrl}`);
           try {
             execSync(`git clone ${gitUrl}`, { cwd: workspace, stdio: 'inherit' });

--- a/init.js
+++ b/init.js
@@ -396,8 +396,14 @@ async function main() {
           ? 'y'  // Non-interactive: auto-clone
           : await askQuestion(`  Clone ${repo}? (Y/n): `);
         if (clone.toLowerCase() !== 'n') {
-          // Repos are stored as full URLs; ensure .git suffix for cloning
-          const gitUrl = repo.endsWith('.git') ? repo : `${repo}.git`;
+          // Repos are stored as full URLs; bare slugs fall back to GitHub for backward compat
+          let gitUrl = repo;
+          if (!gitUrl.startsWith('http://') && !gitUrl.startsWith('https://')) {
+            gitUrl = `https://github.com/${gitUrl}`;
+          }
+          if (!gitUrl.endsWith('.git')) {
+            gitUrl = `${gitUrl}.git`;
+          }
           console.log(`  [CLONE]  ${gitUrl}`);
           try {
             execSync(`git clone ${gitUrl}`, { cwd: workspace, stdio: 'inherit' });

--- a/init.js
+++ b/init.js
@@ -160,6 +160,7 @@ function parseSimpleYaml(content) {
 function writeYaml(config) {
   let yaml = '# Dev Pilot Configuration\n\n';
   yaml += `workspace: ${config.workspace}\n\n`;
+  yaml += `platform: ${config.platform || 'github'}\n\n`;
   yaml += 'repos:\n';
   for (const repo of (config.repos || [])) {
     yaml += `  - ${repo}\n`;
@@ -223,6 +224,32 @@ async function main() {
       config.workspace = answer || defaultWs;
     }
     config.workspace = path.resolve(config.workspace);
+
+    // Platform
+    const PLATFORM_CLI = { github: 'gh', gitlab: 'glab', azdevops: 'az' };
+    const PLATFORM_INSTALL = {
+      github: 'https://cli.github.com',
+      gitlab: 'https://gitlab.com/gitlab-org/cli',
+      azdevops: 'https://aka.ms/azure-cli (+ az devops extension)',
+    };
+
+    console.log('  Git platforms:');
+    console.log('    1) github  — GitHub (uses gh CLI)');
+    console.log('    2) gitlab  — GitLab (uses glab CLI)');
+    console.log('    3) azdevops — Azure DevOps (uses az CLI)');
+    const platformAnswer = await askQuestion('  Platform [1]: ');
+    const platformMap = { '1': 'github', '2': 'gitlab', '3': 'azdevops', '': 'github' };
+    config.platform = platformMap[platformAnswer] || 'github';
+
+    // Check CLI availability
+    const cliBin = PLATFORM_CLI[config.platform];
+    try {
+      execSync(`${cliBin} --version`, { stdio: 'pipe' });
+      console.log(`  ✓ ${cliBin} CLI detected`);
+    } catch {
+      console.log(`  ⚠ ${cliBin} CLI not found. Install it: ${PLATFORM_INSTALL[config.platform]}`);
+      console.log(`    Then authenticate: ${cliBin === 'az' ? 'az login && az devops configure --defaults organization=https://dev.azure.com/YOUR_ORG' : `${cliBin} auth login`}`);
+    }
 
     // Repos
     config.repos = [];
@@ -342,9 +369,15 @@ async function main() {
           ? 'y'  // Non-interactive: auto-clone
           : await askQuestion(`  Clone ${repo}? (Y/n): `);
         if (clone.toLowerCase() !== 'n') {
+          const CLONE_HOSTS = {
+            github: 'https://github.com/',
+            gitlab: 'https://gitlab.com/',
+            azdevops: 'https://dev.azure.com/',
+          };
+          const platform = config.platform || 'github';
           const gitUrl = repo.startsWith('https://')
             ? (repo.endsWith('.git') ? repo : `${repo}.git`)
-            : `https://github.com/${repo}.git`;
+            : `${CLONE_HOSTS[platform]}${repo}.git`;
           console.log(`  [CLONE]  ${gitUrl}`);
           try {
             execSync(`git clone ${gitUrl}`, { cwd: workspace, stdio: 'inherit' });

--- a/pilot.yaml.template
+++ b/pilot.yaml.template
@@ -7,16 +7,20 @@ workspace: ~/claude/workspace
 
 # Git platform — which hosting service to use
 # Options: github, gitlab, azdevops
-# Each platform requires its own CLI tool:
-#   github  → gh     (https://cli.github.com)
-#   gitlab  → glab   (https://gitlab.com/gitlab-org/cli)
-#   azdevops → az    (https://aka.ms/azure-cli + az devops extension)
+# Each platform requires its own CLI tool installed and authenticated:
+#   github   → gh   (https://cli.github.com)           → gh auth login
+#   gitlab   → glab (https://gitlab.com/gitlab-org/cli) → glab auth login
+#   azdevops → az   (https://aka.ms/azure-cli)          → az login
 platform: github
 
-# Repos to work with (owner/repo format)
+# Repos to work with (full git URL)
 # The first repo is the primary target for /pilot-dev-issue
+# Examples:
+#   - https://github.com/your-org/your-repo
+#   - https://gitlab.mycompany.com/team/project
+#   - https://dev.azure.com/org/project/_git/repo
 repos:
-  - your-org/your-repo
+  - https://github.com/your-org/your-repo
 
 # AI platform — which CLI tool to use on the dashboard
 # Options: copilot-cli, claude-code

--- a/pilot.yaml.template
+++ b/pilot.yaml.template
@@ -5,7 +5,15 @@
 # Workspace directory — where repos, logs, and worktrees are stored
 workspace: ~/claude/workspace
 
-# GitHub repos to work with (owner/repo format)
+# Git platform — which hosting service to use
+# Options: github, gitlab, azdevops
+# Each platform requires its own CLI tool:
+#   github  → gh     (https://cli.github.com)
+#   gitlab  → glab   (https://gitlab.com/gitlab-org/cli)
+#   azdevops → az    (https://aka.ms/azure-cli + az devops extension)
+platform: github
+
+# Repos to work with (owner/repo format)
 # The first repo is the primary target for /pilot-dev-issue
 repos:
   - your-org/your-repo


### PR DESCRIPTION
## Summary
- Add platform abstraction layer (`git-provider.ts`) mapping platform-agnostic operations to `gh`/`glab`/`az` CLI tools
- Extend `pilot.yaml.template` and `init.js` with `platform` field (auto-detection + interactive prompt)
- Make dashboard routes, config, and framework commands/agents platform-aware for GitHub, GitLab, and Azure DevOps

Closes [#30](https://github.com/frankliu20/dev-pilot/issues/30)

## Test plan
- [x] TypeScript build passes
- [x] Run `node init.js` and verify platform prompt appears
- [ ] Verify dashboard works with `platform: github` (default, existing behavior)
- [ ] Verify `glab`/`az` CLI paths are correctly resolved in git-provider

🤖 Generated with [Claude Code](https://claude.com/claude-code)