### PR TITLE
docs: add GitHub issue and PR templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,35 @@
+---
+name: Bug Report
+about: Report a bug to help us improve
+title: "bug: "
+labels: bug
+assignees: ""
+---
+
+## Describe the Bug
+
+A clear and concise description of the bug.
+
+## Steps to Reproduce
+
+1. Go to '...'
+2. Run '...'
+3. See error
+
+## Expected Behavior
+
+What you expected to happen.
+
+## Actual Behavior
+
+What actually happened.
+
+## Environment
+
+- OS: [e.g., Windows 11, macOS 14, Ubuntu 22.04]
+- Node.js version: [e.g., 20.x]
+- Claude Code version: [e.g., 1.x]
+
+## Additional Context
+
+Add any other context, screenshots, or log output here.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,23 @@
+---
+name: Feature Request
+about: Suggest a new feature or improvement
+title: "feat: "
+labels: feature
+assignees: ""
+---
+
+## Problem Statement
+
+A clear description of the problem this feature would solve.
+
+## Proposed Solution
+
+Describe how you'd like this to work.
+
+## Alternatives Considered
+
+Any alternative solutions or workarounds you've considered.
+
+## Additional Context
+
+Add any other context, mockups, or examples here.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,25 @@
+## Summary
+
+<!-- Describe what this PR does and why. -->
+
+## Related Issue
+
+<!-- Link to the issue this PR addresses. -->
+
+Closes #
+
+## Changes
+
+- 
+
+## Test Plan
+
+- [ ] Build passes
+- [ ] Tests pass (if applicable)
+- [ ] Manual verification (if applicable)
+
+## Checklist
+
+- [ ] Code follows project conventions
+- [ ] Changes are minimal and focused
+- [ ] Self-reviewed the diff


### PR DESCRIPTION
## Summary
- Add bug report issue template (`.github/ISSUE_TEMPLATE/bug_report.md`)
- Add feature request issue template (`.github/ISSUE_TEMPLATE/feature_request.md`)
- Add pull request template (`.github/PULL_REQUEST_TEMPLATE.md`)

This is a docs-only change — no code or runtime behavior is affected.

Closes #34

## Test plan
- [x] Build only (N/A for docs templates)

🤖 Generated with [Claude Code](https://claude.com/claude-code)