### PR TITLE
chore: add CODEOWNERS — require owner approval for all PRs

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @frankliu20


### PR DESCRIPTION
## Summary
- Add `.github/CODEOWNERS` with `* @frankliu20`
- Combined with branch protection (require code owner review), this ensures only the repo owner can approve and merge PRs

## Test plan
- [ ] Verify CODEOWNERS file is recognized by GitHub
- [ ] Verify other collaborators' PRs require @frankliu20 approval

🤖 Generated with [Claude Code](https://claude.com/claude-code)