### PR TITLE
feat(watch-pr): auto-fix CI failures and review comments

### DIFF
--- a/framework/commands/claude/pilot-watch-pr.md
+++ b/framework/commands/claude/pilot-watch-pr.md
@@ -215,40 +215,22 @@ Maintain a counter per PR per fix type. Persist in `$WS/logs/auto-fix-state.json
 
 Only trigger when CI **newly failed** (not already failing from last cycle with same error).
 
-1. **Fetch failed CI logs** (to include as context, platform-specific):
-
-**GitHub:**
-```bash
-FAILED_RUN=$(gh run list --repo $REPO_SLUG --branch <branch> --status failure --limit 1 --json databaseId --jq '.[0].databaseId')
-CI_LOG=$(gh run view $FAILED_RUN --repo $REPO_SLUG --log-failed 2>&1 | tail -200)
-```
-
-**GitLab:**
-```bash
-CI_LOG=$(glab ci view --repo $REPO_SLUG --branch <branch> 2>&1 | tail -200)
-```
-
-**Azure DevOps:**
-```bash
-CI_LOG=$(az pipelines runs list --branch <branch> --status completed --result failed --top 1 --output json 2>&1 | tail -200)
-```
-
-2. **Spawn `pilot-dev-issue` with `--auto`** to fix in the existing worktree:
+1. **Spawn `pilot-dev-issue` with `--auto`**:
 ```
 Skill(
   skill="pilot-dev-issue",
-  args="--auto CI failure on PR #<N> (branch: <branch>). Fix the following CI error and push to the existing branch.\n\nCI log (last 200 lines):\n<CI_LOG>"
+  args="--auto Fix failing CI on PR #<N> (repo: $REPO_SLUG, branch: <branch>). Diagnose the CI failure and push a fix."
 )
 ```
-`pilot-dev-issue --auto` will: reuse the existing worktree for the branch, analyze the failure, fix the code, build-verify, commit, and push — all without user prompts.
+`pilot-dev-issue` will handle everything: fetch CI logs, analyze the failure, fix the code, build-verify, commit, and push.
 
-3. **After completion**:
+2. **After completion**:
    - Increment `ci_attempts` for this PR
    - Log event: `ci_auto_fix` with detail
    - Update notification: "Auto-fix pushed, waiting for CI..."
    - Next cycle will pick up the new CI result
 
-4. **If max attempts (3) reached**:
+3. **If max attempts (3) reached**:
    - Write notification asking user to intervene
    - Log `auto_fix_blocked` event
    - Stop auto-fixing this PR's CI until user dismisses or CI changes
@@ -257,34 +239,17 @@ Skill(
 
 Only trigger when **new** unresolved comments appear (count increased since last cycle).
 
-1. **Fetch unresolved comment details** (to include as context):
-```bash
-COMMENTS=$(gh api graphql -f query='
-query($owner:String!,$repo:String!,$number:Int!) {
-  repository(owner:$owner,name:$repo) {
-    pullRequest(number:$number) {
-      reviewThreads(first:50) {
-        nodes {
-          isResolved path line
-          comments(first:10) { nodes { body author { login } } }
-        }
-      }
-    }
-  }
-}' -f owner="$OWNER" -f repo="$REPO_NAME" -F number=$PR_NUMBER)
-```
-
-2. **Spawn `pilot-dev-issue` with `--auto`**:
+1. **Spawn `pilot-dev-issue` with `--auto`**:
 ```
 Skill(
   skill="pilot-dev-issue",
-  args="--auto Address unresolved review comments on PR #<N> (branch: <branch>). Fix the code as requested and push to the existing branch.\n\nUnresolved comments:\n<COMMENTS>"
+  args="--auto Address unresolved review comments on PR #<N> (repo: $REPO_SLUG, branch: <branch>). Read the comments, fix the code, and push."
 )
 ```
 
-3. **After completion**: increment `comment_attempts`, log event, update notification.
+2. **After completion**: increment `comment_attempts`, log event, update notification.
 
-4. **If max attempts (3) reached**: same as CI — notify user and stop.
+3. **If max attempts (3) reached**: same as CI — notify user and stop.
 
 #### Status log events for auto-fix:
 ```bash

--- a/framework/commands/claude/pilot-watch-pr.md
+++ b/framework/commands/claude/pilot-watch-pr.md
@@ -174,7 +174,7 @@ NOTIFICATION
 
 ### Step 5: Auto-Fix Actions
 
-After detecting and reporting, attempt auto-fix for enabled conditions. Track attempts per PR in the cycle state.
+After detecting and reporting, delegate fixes to `/pilot-dev-issue` which already handles the full analyze → fix → test → commit → push flow.
 
 #### Auto-Fix State Tracking
 
@@ -192,134 +192,64 @@ Maintain a counter per PR per fix type. Persist in `$WS/logs/auto-fix-state.json
 
 Only trigger when CI **newly failed** (not already failing from last cycle with same error).
 
-1. **Fetch failed CI logs**:
+1. **Fetch failed CI logs** (to include as context):
 ```bash
-# Get the failed run ID from the PR's head branch
 FAILED_RUN=$(gh run list --repo $REPO_SLUG --branch <branch> --status failure --limit 1 --json databaseId --jq '.[0].databaseId')
-# Fetch only the failed job logs (not the full run)
-gh run view $FAILED_RUN --repo $REPO_SLUG --log-failed 2>&1 | tail -200
+CI_LOG=$(gh run view $FAILED_RUN --repo $REPO_SLUG --log-failed 2>&1 | tail -200)
 ```
 
-2. **Locate or create the worktree**:
-```bash
-WORKTREE="$WS/worktrees/issue-<linked-issue-number>"
-# If no worktree exists for this branch, create one:
-if [ ! -d "$WORKTREE" ]; then
-  cd "$WS/<repo-name>"
-  git fetch origin
-  git worktree add "$WORKTREE" origin/<branch>
-fi
-cd "$WORKTREE"
-git pull origin <branch>
+2. **Spawn `pilot-dev-issue` with `--auto`** to fix in the existing worktree:
 ```
-
-3. **Spawn a fix agent**:
-```
-Agent(
-  description="Fix CI failure for PR #<N>",
-  subagent_type="general-purpose",
-  prompt="You are fixing a CI failure on branch <branch> in the repo at <worktree-path>.
-
-CI failed with the following log (last 200 lines):
-<failed log output>
-
-Instructions:
-1. Analyze the failure — identify the root cause (build error, test failure, lint error, etc.)
-2. Fix the code — make minimal changes to resolve the issue
-3. Run the build command to verify: <build command from pilot.yaml>
-4. Stage and commit the fix: git add <files> && git commit -m 'fix(ci): <description>'
-5. Push: git push origin <branch>
-
-Rules:
-- Minimal changes only — fix the CI issue, nothing else
-- Never force push
-- If you cannot determine the fix after examining the code, report what you found and stop
-"
+Skill(
+  skill="pilot-dev-issue",
+  args="--auto CI failure on PR #<N> (branch: <branch>). Fix the following CI error and push to the existing branch.\n\nCI log (last 200 lines):\n<CI_LOG>"
 )
 ```
+`pilot-dev-issue --auto` will: reuse the existing worktree for the branch, analyze the failure, fix the code, build-verify, commit, and push — all without user prompts.
 
-4. **After agent completes**:
+3. **After completion**:
    - Increment `ci_attempts` for this PR
-   - Log event: `ci_auto_fix` with detail of what was changed
-   - Update notification: replace with "Auto-fix pushed, waiting for CI..."
+   - Log event: `ci_auto_fix` with detail
+   - Update notification: "Auto-fix pushed, waiting for CI..."
    - Next cycle will pick up the new CI result
 
-5. **If max attempts (3) reached**:
-   - Write notification asking user to intervene:
-   ```json
-   {
-     "question": "PR #<N> CI still failing after 3 auto-fix attempts",
-     "options": ["Review Logs", "Dismiss"],
-     "context": "<summary of all 3 attempts>"
-   }
-   ```
-   - Log `blocked` event
+4. **If max attempts (3) reached**:
+   - Write notification asking user to intervene
+   - Log `auto_fix_blocked` event
    - Stop auto-fixing this PR's CI until user dismisses or CI changes
 
 #### Review Comments Auto-Fix (when `auto_fix_comments: true`)
 
 Only trigger when **new** unresolved comments appear (count increased since last cycle).
 
-1. **Fetch full comment details**:
+1. **Fetch unresolved comment details** (to include as context):
 ```bash
-gh api graphql -f query='
+COMMENTS=$(gh api graphql -f query='
 query($owner:String!,$repo:String!,$number:Int!) {
   repository(owner:$owner,name:$repo) {
     pullRequest(number:$number) {
       reviewThreads(first:50) {
         nodes {
-          id
-          isResolved
-          path
-          line
-          comments(first:10) {
-            nodes { body author { login } createdAt }
-          }
+          isResolved path line
+          comments(first:10) { nodes { body author { login } } }
         }
       }
     }
   }
-}' -f owner="$OWNER" -f repo="$REPO_NAME" -F number=$PR_NUMBER
+}' -f owner="$OWNER" -f repo="$REPO_NAME" -F number=$PR_NUMBER)
 ```
 
-2. **Locate or create the worktree** (same as CI fix above).
-
-3. **Spawn a fix agent**:
+2. **Spawn `pilot-dev-issue` with `--auto`**:
 ```
-Agent(
-  description="Fix review comments for PR #<N>",
-  subagent_type="general-purpose",
-  prompt="You are addressing review comments on PR #<N>, branch <branch> in the repo at <worktree-path>.
-
-Unresolved review comments:
-<for each unresolved thread>
-- File: <path>, Line: <line>
-  Reviewer: <author>
-  Comment: <body>
-</for each>
-
-Instructions:
-1. Read each comment and understand what the reviewer is asking for
-2. Make the requested code changes
-3. Run the build command to verify: <build command from pilot.yaml>
-4. Stage and commit: git add <files> && git commit -m 'fix(review): address review comments on PR #<N>'
-5. Push: git push origin <branch>
-
-Rules:
-- Address ALL unresolved comments in a single commit
-- Minimal changes — only what the reviewers asked for
-- Never force push
-- If a comment is ambiguous or requires a design decision, skip it and note which comments were skipped
-"
+Skill(
+  skill="pilot-dev-issue",
+  args="--auto Address unresolved review comments on PR #<N> (branch: <branch>). Fix the code as requested and push to the existing branch.\n\nUnresolved comments:\n<COMMENTS>"
 )
 ```
 
-4. **After agent completes**:
-   - Increment `comment_attempts` for this PR
-   - Log event: `comment_auto_fix` with detail of what was addressed
-   - Update notification with fix status
+3. **After completion**: increment `comment_attempts`, log event, update notification.
 
-5. **If max attempts (3) reached**: same as CI — notify user and stop.
+4. **If max attempts (3) reached**: same as CI — notify user and stop.
 
 #### Status log events for auto-fix:
 ```bash
@@ -333,7 +263,6 @@ New event types: `ci_failure`, `ci_auto_fix`, `ci_auto_fix_failed`, `comment_aut
   2. Remove auto-fix state for this PR from `auto-fix-state.json`
   3. Find and remove the worktree for this PR's branch:
      ```bash
-     # Find repo and worktree by branch name
      cd "$WS/<repo-name>"
      WORKTREE=$(git worktree list --porcelain | grep -B1 "branch refs/heads/<branch>" | head -1 | sed 's/worktree //')
      if [ -n "$WORKTREE" ]; then
@@ -365,8 +294,9 @@ PR Monitor — <time> — no open PRs
 4. **Only report changes** — don't repeat known status
 5. **Never auto-merge** — only notify
 6. **My PRs only** — ignore other people's PRs
-7. **Auto-fix CI is on by default** — disable via `watch_pr.auto_fix_ci: false` in `pilot.yaml`
-8. **Auto-fix comments is off by default** — enable via `watch_pr.auto_fix_comments: true` in `pilot.yaml`
-9. **Max 3 auto-fix attempts** per PR per fix type — then stop and notify user
-10. **Never force push** — all fixes are new commits
-11. **Log all auto-fix actions** — every fix attempt is logged to `$WS/logs/pr-<N>.jsonl`
+7. **Auto-fix delegates to `/pilot-dev-issue --auto`** — reuses existing worktrees, full fix pipeline
+8. **Auto-fix CI is on by default** — disable via `watch_pr.auto_fix_ci: false` in `pilot.yaml`
+9. **Auto-fix comments is off by default** — enable via `watch_pr.auto_fix_comments: true` in `pilot.yaml`
+10. **Max 3 auto-fix attempts** per PR per fix type — then stop and notify user
+11. **Never force push** — all fixes are new commits
+12. **Log all auto-fix actions** — every fix attempt is logged to `$WS/logs/pr-<N>.jsonl`

--- a/framework/commands/claude/pilot-watch-pr.md
+++ b/framework/commands/claude/pilot-watch-pr.md
@@ -60,7 +60,9 @@ Cron job ID: <id> — cancel anytime with CronDelete.
 
 ### Step 1: Fetch my open PRs from ALL repos
 
-For each repo in `$REPOS`:
+For each repo in `$REPOS`, use the platform-appropriate CLI:
+
+#### GitHub (`$PLATFORM == github`):
 ```bash
 gh pr list --repo $REPO_SLUG \
   --author @me \
@@ -69,7 +71,26 @@ gh pr list --repo $REPO_SLUG \
   --limit 20
 ```
 
-For each PR with `reviewDecision` of `CHANGES_REQUESTED` or `REVIEW_REQUIRED`, also fetch unresolved review threads:
+#### GitLab (`$PLATFORM == gitlab`):
+```bash
+glab mr list --repo $REPO_SLUG \
+  --author @me \
+  --state opened \
+  --output json
+```
+
+#### Azure DevOps (`$PLATFORM == azdevops`):
+```bash
+az repos pr list \
+  --repository $REPO_SLUG \
+  --creator @me \
+  --status active \
+  --output json
+```
+
+#### Fetch unresolved review threads (GitHub only):
+
+For each PR with `reviewDecision` of `CHANGES_REQUESTED` or `REVIEW_REQUIRED`:
 ```bash
 gh api graphql -f query='
 query($owner:String!,$repo:String!,$number:Int!) {
@@ -87,6 +108,8 @@ query($owner:String!,$repo:String!,$number:Int!) {
   }
 }' -f owner="$OWNER" -f repo="$REPO_NAME" -F number=$PR_NUMBER
 ```
+
+**Note**: GitLab and Azure DevOps do not support GraphQL review thread queries. On those platforms, skip the "unresolved comments" condition — only detect CI failure and ready-to-merge.
 
 ### Step 2: Detect THREE conditions
 
@@ -192,10 +215,22 @@ Maintain a counter per PR per fix type. Persist in `$WS/logs/auto-fix-state.json
 
 Only trigger when CI **newly failed** (not already failing from last cycle with same error).
 
-1. **Fetch failed CI logs** (to include as context):
+1. **Fetch failed CI logs** (to include as context, platform-specific):
+
+**GitHub:**
 ```bash
 FAILED_RUN=$(gh run list --repo $REPO_SLUG --branch <branch> --status failure --limit 1 --json databaseId --jq '.[0].databaseId')
 CI_LOG=$(gh run view $FAILED_RUN --repo $REPO_SLUG --log-failed 2>&1 | tail -200)
+```
+
+**GitLab:**
+```bash
+CI_LOG=$(glab ci view --repo $REPO_SLUG --branch <branch> 2>&1 | tail -200)
+```
+
+**Azure DevOps:**
+```bash
+CI_LOG=$(az pipelines runs list --branch <branch> --status completed --result failed --top 1 --output json 2>&1 | tail -200)
 ```
 
 2. **Spawn `pilot-dev-issue` with `--auto`** to fix in the existing worktree:

--- a/framework/commands/claude/pilot-watch-pr.md
+++ b/framework/commands/claude/pilot-watch-pr.md
@@ -1,9 +1,20 @@
-You are a lightweight PR monitoring daemon. **Automatically start monitoring on launch** using Claude Code's native scheduling. No need to ask the user.
+You are a PR monitoring daemon with auto-fix capabilities. **Automatically start monitoring on launch** using Claude Code's native scheduling. No need to ask the user.
 
 ## Context
 
 - **Repos**: Read `~/.claude/pilot.yaml` → use the full `repos` list. Monitor PRs across ALL configured repos.
 - **Scope**: Only my own PRs (`--author @me`).
+
+## Configuration
+
+Read `~/.claude/pilot.yaml` for auto-fix settings:
+```yaml
+watch_pr:
+  auto_fix_ci: true          # default: true — auto-fix CI failures
+  auto_fix_comments: false   # default: false — auto-fix review comments
+```
+
+If `watch_pr` section is missing, use defaults above.
 
 ## Workspace
 
@@ -32,13 +43,14 @@ Use the correct CLI based on `$PLATFORM`. GraphQL review thread checks only work
 ```
 CronCreate(
   cron="*/10 * * * *",
-  prompt="Run PR monitoring check cycle: fetch my open PRs from all repos in ~/.claude/pilot.yaml, detect new unresolved comments or ready-to-merge status, and report changes. See /pilot-watch-pr for full instructions.",
+  prompt="Run PR monitoring check cycle: fetch my open PRs from all repos in ~/.claude/pilot.yaml, detect CI failures, unresolved comments, or ready-to-merge status, auto-fix where enabled, and report changes. See /pilot-watch-pr for full instructions.",
   recurring=true
 )
 ```
 3. **Report to user**:
 ```
 PR Monitor started. Checking every 10 minutes (auto-expires after 7 days).
+Auto-fix CI: <on/off>  |  Auto-fix comments: <on/off>
 Cron job ID: <id> — cancel anytime with CronDelete.
 ```
 
@@ -76,18 +88,20 @@ query($owner:String!,$repo:String!,$number:Int!) {
 }' -f owner="$OWNER" -f repo="$REPO_NAME" -F number=$PR_NUMBER
 ```
 
-### Step 2: Detect only TWO conditions
+### Step 2: Detect THREE conditions
 
 | Condition | How to detect |
 |-----------|---------------|
+| **CI failure** | `statusCheckRollup` contains any check with `conclusion` of `FAILURE`, `ERROR`, `TIMED_OUT`, or `STARTUP_FAILURE` |
 | **New unresolved comments** | PR has unresolved review threads (`isResolved: false`) |
 | **Ready to merge** | `reviewDecision === "APPROVED"` AND all status checks pass AND not a draft |
 
 ### Step 3: Compare with last check — only act on NEW changes
 
-Track state from the previous cycle. Only report when something **changed**:
+Track state from the previous cycle. Only report/act when something **changed**:
 
-- **New unresolved comments appeared** (count increased) → report
+- **CI just failed** (was passing or pending before) → report + auto-fix if enabled
+- **New unresolved comments appeared** (count increased) → report + auto-fix if enabled
 - **PR just became ready to merge** (wasn't ready before) → report
 
 If nothing changed:
@@ -102,15 +116,32 @@ When a condition is detected and it's **NEW** (changed since last cycle):
 #### Terminal output (one line per PR):
 ```
 PR Monitor — <time>
+❌ #5130 Add retry logic — CI failed (build error) — auto-fixing...
 💬 #5124 Disable fail-fast — 3 unresolved comments
 ✅ #5098 PostToolUse hook — approved & CI green, ready to merge!
 ```
 
 #### Dashboard notification file:
 
-For **unresolved comments**:
+For **CI failure**:
 ```bash
 mkdir -p "$WS/logs/pending-decisions"
+cat > "$WS/logs/pending-decisions/pr-<N>.json" << 'NOTIFICATION'
+{
+  "taskId": "pr-<N>",
+  "issueNumber": null,
+  "prNumber": <N>,
+  "phase": "pr_notification",
+  "question": "PR #<N> CI failed: <failure summary>",
+  "options": ["Auto-fixing...", "Review Logs", "Dismiss"],
+  "context": "<failed job names and brief error>",
+  "timestamp": "<ISO8601>"
+}
+NOTIFICATION
+```
+
+For **unresolved comments**:
+```bash
 cat > "$WS/logs/pending-decisions/pr-<N>.json" << 'NOTIFICATION'
 {
   "taskId": "pr-<N>",
@@ -141,16 +172,166 @@ cat > "$WS/logs/pending-decisions/pr-<N>.json" << 'NOTIFICATION'
 NOTIFICATION
 ```
 
-#### Status log:
+### Step 5: Auto-Fix Actions
+
+After detecting and reporting, attempt auto-fix for enabled conditions. Track attempts per PR in the cycle state.
+
+#### Auto-Fix State Tracking
+
+Maintain a counter per PR per fix type. Persist in `$WS/logs/auto-fix-state.json`:
+```json
+{
+  "pr-123": { "ci_attempts": 0, "comment_attempts": 0 },
+  "pr-456": { "ci_attempts": 2, "comment_attempts": 1 }
+}
+```
+- **Max 3 attempts** per PR per fix type. After 3 failed attempts, stop and notify user.
+- Reset counters when: PR is merged/closed, or CI goes green, or comments are resolved.
+
+#### CI Failure Auto-Fix (when `auto_fix_ci: true`)
+
+Only trigger when CI **newly failed** (not already failing from last cycle with same error).
+
+1. **Fetch failed CI logs**:
+```bash
+# Get the failed run ID from the PR's head branch
+FAILED_RUN=$(gh run list --repo $REPO_SLUG --branch <branch> --status failure --limit 1 --json databaseId --jq '.[0].databaseId')
+# Fetch only the failed job logs (not the full run)
+gh run view $FAILED_RUN --repo $REPO_SLUG --log-failed 2>&1 | tail -200
+```
+
+2. **Locate or create the worktree**:
+```bash
+WORKTREE="$WS/worktrees/issue-<linked-issue-number>"
+# If no worktree exists for this branch, create one:
+if [ ! -d "$WORKTREE" ]; then
+  cd "$WS/<repo-name>"
+  git fetch origin
+  git worktree add "$WORKTREE" origin/<branch>
+fi
+cd "$WORKTREE"
+git pull origin <branch>
+```
+
+3. **Spawn a fix agent**:
+```
+Agent(
+  description="Fix CI failure for PR #<N>",
+  subagent_type="general-purpose",
+  prompt="You are fixing a CI failure on branch <branch> in the repo at <worktree-path>.
+
+CI failed with the following log (last 200 lines):
+<failed log output>
+
+Instructions:
+1. Analyze the failure — identify the root cause (build error, test failure, lint error, etc.)
+2. Fix the code — make minimal changes to resolve the issue
+3. Run the build command to verify: <build command from pilot.yaml>
+4. Stage and commit the fix: git add <files> && git commit -m 'fix(ci): <description>'
+5. Push: git push origin <branch>
+
+Rules:
+- Minimal changes only — fix the CI issue, nothing else
+- Never force push
+- If you cannot determine the fix after examining the code, report what you found and stop
+"
+)
+```
+
+4. **After agent completes**:
+   - Increment `ci_attempts` for this PR
+   - Log event: `ci_auto_fix` with detail of what was changed
+   - Update notification: replace with "Auto-fix pushed, waiting for CI..."
+   - Next cycle will pick up the new CI result
+
+5. **If max attempts (3) reached**:
+   - Write notification asking user to intervene:
+   ```json
+   {
+     "question": "PR #<N> CI still failing after 3 auto-fix attempts",
+     "options": ["Review Logs", "Dismiss"],
+     "context": "<summary of all 3 attempts>"
+   }
+   ```
+   - Log `blocked` event
+   - Stop auto-fixing this PR's CI until user dismisses or CI changes
+
+#### Review Comments Auto-Fix (when `auto_fix_comments: true`)
+
+Only trigger when **new** unresolved comments appear (count increased since last cycle).
+
+1. **Fetch full comment details**:
+```bash
+gh api graphql -f query='
+query($owner:String!,$repo:String!,$number:Int!) {
+  repository(owner:$owner,name:$repo) {
+    pullRequest(number:$number) {
+      reviewThreads(first:50) {
+        nodes {
+          id
+          isResolved
+          path
+          line
+          comments(first:10) {
+            nodes { body author { login } createdAt }
+          }
+        }
+      }
+    }
+  }
+}' -f owner="$OWNER" -f repo="$REPO_NAME" -F number=$PR_NUMBER
+```
+
+2. **Locate or create the worktree** (same as CI fix above).
+
+3. **Spawn a fix agent**:
+```
+Agent(
+  description="Fix review comments for PR #<N>",
+  subagent_type="general-purpose",
+  prompt="You are addressing review comments on PR #<N>, branch <branch> in the repo at <worktree-path>.
+
+Unresolved review comments:
+<for each unresolved thread>
+- File: <path>, Line: <line>
+  Reviewer: <author>
+  Comment: <body>
+</for each>
+
+Instructions:
+1. Read each comment and understand what the reviewer is asking for
+2. Make the requested code changes
+3. Run the build command to verify: <build command from pilot.yaml>
+4. Stage and commit: git add <files> && git commit -m 'fix(review): address review comments on PR #<N>'
+5. Push: git push origin <branch>
+
+Rules:
+- Address ALL unresolved comments in a single commit
+- Minimal changes — only what the reviewers asked for
+- Never force push
+- If a comment is ambiguous or requires a design decision, skip it and note which comments were skipped
+"
+)
+```
+
+4. **After agent completes**:
+   - Increment `comment_attempts` for this PR
+   - Log event: `comment_auto_fix` with detail of what was addressed
+   - Update notification with fix status
+
+5. **If max attempts (3) reached**: same as CI — notify user and stop.
+
+#### Status log events for auto-fix:
 ```bash
 echo '{"timestamp":"<ISO8601>","task_id":"pr-<N>","type":"<event>","phase":"pr_monitor","pr_number":<N>,"detail":"<message>"}' >> "$WS/logs/pr-<N>.jsonl"
 ```
-Event types: `review_comments`, `ready_to_merge`, `pr_merged`
+New event types: `ci_failure`, `ci_auto_fix`, `ci_auto_fix_failed`, `comment_auto_fix`, `comment_auto_fix_failed`, `auto_fix_blocked`
 
 #### Cleanup:
 - PR merged/closed → **auto-cleanup**:
   1. Delete notification: `rm -f "$WS/logs/pending-decisions/pr-<N>.json"`
-  2. Find and remove the worktree for this PR's branch:
+  2. Remove auto-fix state for this PR from `auto-fix-state.json`
+  3. Find and remove the worktree for this PR's branch:
      ```bash
      # Find repo and worktree by branch name
      cd "$WS/<repo-name>"
@@ -160,9 +341,10 @@ Event types: `review_comments`, `ready_to_merge`, `pr_merged`
        git branch -D "<branch>"
      fi
      ```
-  3. Also check `.claude/worktrees/` for native worktrees matching the branch
-  4. Log `pr_merged` event
-- Unresolved comments drop to 0 → delete notification
+  4. Also check `.claude/worktrees/` for native worktrees matching the branch
+  5. Log `pr_merged` event
+- CI goes green → reset `ci_attempts` to 0 for that PR
+- Unresolved comments drop to 0 → delete notification, reset `comment_attempts`
 - Same PR already has notification → overwrite with latest state
 
 If nothing changed:
@@ -179,8 +361,12 @@ PR Monitor — <time> — no open PRs
 
 1. **Start immediately** — no confirmation needed
 2. **10-minute interval** via CronCreate — fires only when session is idle
-3. **Only two conditions** — unresolved comments and ready-to-merge. Ignore everything else.
+3. **Three conditions** — CI failure, unresolved comments, and ready-to-merge
 4. **Only report changes** — don't repeat known status
 5. **Never auto-merge** — only notify
 6. **My PRs only** — ignore other people's PRs
-7. **Keep it simple** — no auto-fix, no worktree management, no CI analysis
+7. **Auto-fix CI is on by default** — disable via `watch_pr.auto_fix_ci: false` in `pilot.yaml`
+8. **Auto-fix comments is off by default** — enable via `watch_pr.auto_fix_comments: true` in `pilot.yaml`
+9. **Max 3 auto-fix attempts** per PR per fix type — then stop and notify user
+10. **Never force push** — all fixes are new commits
+11. **Log all auto-fix actions** — every fix attempt is logged to `$WS/logs/pr-<N>.jsonl`

--- a/framework/commands/copilot/pilot-watch-pr.md
+++ b/framework/commands/copilot/pilot-watch-pr.md
@@ -160,40 +160,19 @@ Maintain a counter per PR per fix type. Persist in `$WS/logs/auto-fix-state.json
 
 Only trigger when CI **newly failed** (not already failing from last cycle with same error).
 
-1. **Fetch failed CI logs** (to include as context, platform-specific):
-
-**GitHub:**
-```bash
-FAILED_RUN=$(gh run list --repo $REPO_SLUG --branch <branch> --status failure --limit 1 --json databaseId --jq '.[0].databaseId')
-CI_LOG=$(gh run view $FAILED_RUN --repo $REPO_SLUG --log-failed 2>&1 | tail -200)
+1. **Invoke `/pilot-dev-issue --auto`**:
 ```
-
-**GitLab:**
-```bash
-CI_LOG=$(glab ci view --repo $REPO_SLUG --branch <branch> 2>&1 | tail -200)
+/pilot-dev-issue --auto Fix failing CI on PR #<N> (repo: $REPO_SLUG, branch: <branch>). Diagnose the CI failure and push a fix.
 ```
+`pilot-dev-issue` will handle everything: fetch CI logs, analyze the failure, fix the code, build-verify, commit, and push.
 
-**Azure DevOps:**
-```bash
-CI_LOG=$(az pipelines runs list --branch <branch> --status completed --result failed --top 1 --output json 2>&1 | tail -200)
-```
-
-2. **Invoke `/pilot-dev-issue --auto`** to fix in the existing worktree:
-```
-/pilot-dev-issue --auto CI failure on PR #<N> (branch: <branch>). Fix the following CI error and push to the existing branch.
-
-CI log (last 200 lines):
-<CI_LOG>
-```
-`pilot-dev-issue --auto` will: reuse the existing worktree for the branch, analyze the failure, fix the code, build-verify, commit, and push — all without user prompts.
-
-3. **After completion**:
+2. **After completion**:
    - Increment `ci_attempts` for this PR
    - Log event: `ci_auto_fix`
    - Update notification: "Auto-fix pushed, waiting for CI..."
    - Next cycle will pick up the new CI result
 
-4. **If max attempts (3) reached or fix cannot be determined**:
+3. **If max attempts (3) reached or fix cannot be determined**:
    - Write notification asking user to intervene
    - Log `auto_fix_blocked` event
    - Stop auto-fixing this PR's CI
@@ -202,34 +181,14 @@ CI log (last 200 lines):
 
 Only trigger when **new** unresolved comments appear (count increased since last cycle).
 
-1. **Fetch unresolved comment details** (to include as context):
-```bash
-COMMENTS=$(gh api graphql -f query='
-query($owner:String!,$repo:String!,$number:Int!) {
-  repository(owner:$owner,name:$repo) {
-    pullRequest(number:$number) {
-      reviewThreads(first:50) {
-        nodes {
-          isResolved path line
-          comments(first:10) { nodes { body author { login } } }
-        }
-      }
-    }
-  }
-}' -f owner="$OWNER" -f repo="$REPO_NAME" -F number=$PR_NUMBER)
+1. **Invoke `/pilot-dev-issue --auto`**:
+```
+/pilot-dev-issue --auto Address unresolved review comments on PR #<N> (repo: $REPO_SLUG, branch: <branch>). Read the comments, fix the code, and push.
 ```
 
-2. **Invoke `/pilot-dev-issue --auto`**:
-```
-/pilot-dev-issue --auto Address unresolved review comments on PR #<N> (branch: <branch>). Fix the code as requested and push to the existing branch.
+2. **After completion**: increment `comment_attempts`, log event, update notification.
 
-Unresolved comments:
-<COMMENTS>
-```
-
-3. **After completion**: increment `comment_attempts`, log event, update notification.
-
-4. **If max attempts (3) reached**: same as CI — notify user and stop.
+3. **If max attempts (3) reached**: same as CI — notify user and stop.
 
 ## Dashboard Notifications
 

--- a/framework/commands/copilot/pilot-watch-pr.md
+++ b/framework/commands/copilot/pilot-watch-pr.md
@@ -137,42 +137,28 @@ Maintain a counter per PR per fix type. Persist in `$WS/logs/auto-fix-state.json
 
 Only trigger when CI **newly failed** (not already failing from last cycle with same error).
 
-1. **Fetch failed CI logs**:
+1. **Fetch failed CI logs** (to include as context):
 ```bash
 FAILED_RUN=$(gh run list --repo $REPO_SLUG --branch <branch> --status failure --limit 1 --json databaseId --jq '.[0].databaseId')
-gh run view $FAILED_RUN --repo $REPO_SLUG --log-failed 2>&1 | tail -200
+CI_LOG=$(gh run view $FAILED_RUN --repo $REPO_SLUG --log-failed 2>&1 | tail -200)
 ```
 
-2. **Locate or create the worktree**:
-```bash
-WORKTREE="$WS/worktrees/issue-<linked-issue-number>"
-if [ ! -d "$WORKTREE" ]; then
-  cd "$WS/<repo-name>"
-  git fetch origin
-  git worktree add "$WORKTREE" origin/<branch>
-fi
-cd "$WORKTREE"
-git pull origin <branch>
+2. **Invoke `/pilot-dev-issue --auto`** to fix in the existing worktree:
 ```
+/pilot-dev-issue --auto CI failure on PR #<N> (branch: <branch>). Fix the following CI error and push to the existing branch.
 
-3. **Fix the issue inline** (Copilot does not have Agent tool):
-   - Analyze the CI log to identify root cause (build error, test failure, lint error)
-   - `cd` into the worktree and fix the code — minimal changes only
-   - Run the build command to verify the fix
-   - Stage, commit, and push:
-   ```bash
-   git add <files>
-   git commit -m "fix(ci): <description of fix>"
-   git push origin <branch>
-   ```
+CI log (last 200 lines):
+<CI_LOG>
+```
+`pilot-dev-issue --auto` will: reuse the existing worktree for the branch, analyze the failure, fix the code, build-verify, commit, and push — all without user prompts.
 
-4. **After fix**:
+3. **After completion**:
    - Increment `ci_attempts` for this PR
    - Log event: `ci_auto_fix`
    - Update notification: "Auto-fix pushed, waiting for CI..."
    - Next cycle will pick up the new CI result
 
-5. **If max attempts (3) reached or fix cannot be determined**:
+4. **If max attempts (3) reached or fix cannot be determined**:
    - Write notification asking user to intervene
    - Log `auto_fix_blocked` event
    - Stop auto-fixing this PR's CI
@@ -181,44 +167,34 @@ git pull origin <branch>
 
 Only trigger when **new** unresolved comments appear (count increased since last cycle).
 
-1. **Fetch full comment details**:
+1. **Fetch unresolved comment details** (to include as context):
 ```bash
-gh api graphql -f query='
+COMMENTS=$(gh api graphql -f query='
 query($owner:String!,$repo:String!,$number:Int!) {
   repository(owner:$owner,name:$repo) {
     pullRequest(number:$number) {
       reviewThreads(first:50) {
         nodes {
-          id
-          isResolved
-          path
-          line
-          comments(first:10) {
-            nodes { body author { login } createdAt }
-          }
+          isResolved path line
+          comments(first:10) { nodes { body author { login } } }
         }
       }
     }
   }
-}' -f owner="$OWNER" -f repo="$REPO_NAME" -F number=$PR_NUMBER
+}' -f owner="$OWNER" -f repo="$REPO_NAME" -F number=$PR_NUMBER)
 ```
 
-2. **Locate or create the worktree** (same as CI fix above).
+2. **Invoke `/pilot-dev-issue --auto`**:
+```
+/pilot-dev-issue --auto Address unresolved review comments on PR #<N> (branch: <branch>). Fix the code as requested and push to the existing branch.
 
-3. **Fix inline**:
-   - Read each unresolved comment and understand the reviewer's request
-   - Make the requested code changes in the worktree
-   - Run the build command to verify
-   - Stage, commit, and push:
-   ```bash
-   git add <files>
-   git commit -m "fix(review): address review comments on PR #<N>"
-   git push origin <branch>
-   ```
+Unresolved comments:
+<COMMENTS>
+```
 
-4. **After fix**: increment `comment_attempts`, log event, update notification.
+3. **After completion**: increment `comment_attempts`, log event, update notification.
 
-5. **If max attempts (3) reached**: same as CI — notify user and stop.
+4. **If max attempts (3) reached**: same as CI — notify user and stop.
 
 ## Dashboard Notifications
 
@@ -311,9 +287,10 @@ Event types: `review_comments`, `ready_to_merge`, `pr_merged`, `ci_failure`, `ci
 4. **Only elaborate on changes** — don't repeat known status
 5. **Never auto-merge** — only notify
 6. **My PRs only** — ignore other people's PRs
-7. **Auto-fix CI is on by default** — disable via `watch_pr.auto_fix_ci: false` in `pilot.yaml`
-8. **Auto-fix comments is off by default** — enable via `watch_pr.auto_fix_comments: true` in `pilot.yaml`
-9. **Max 3 auto-fix attempts** per PR per fix type — then stop and notify user
-10. **Never force push** — all fixes are new commits
-11. **Log all auto-fix actions** — every fix attempt is logged
-12. **Notifications are fire-and-forget** — don't wait for terminal input
+7. **Auto-fix delegates to `/pilot-dev-issue --auto`** — reuses existing worktrees, full fix pipeline
+8. **Auto-fix CI is on by default** — disable via `watch_pr.auto_fix_ci: false` in `pilot.yaml`
+9. **Auto-fix comments is off by default** — enable via `watch_pr.auto_fix_comments: true` in `pilot.yaml`
+10. **Max 3 auto-fix attempts** per PR per fix type — then stop and notify user
+11. **Never force push** — all fixes are new commits
+12. **Log all auto-fix actions** — every fix attempt is logged
+13. **Notifications are fire-and-forget** — don't wait for terminal input

--- a/framework/commands/copilot/pilot-watch-pr.md
+++ b/framework/commands/copilot/pilot-watch-pr.md
@@ -54,7 +54,9 @@ Auto-fix CI: <on/off>  |  Auto-fix comments: <on/off>
 
 ### Step 1: Fetch my open PRs from ALL repos
 
-For each repo in `$REPOS`:
+For each repo in `$REPOS`, use the platform-appropriate CLI:
+
+#### GitHub (`$PLATFORM == github`):
 ```bash
 gh pr list --repo $REPO_SLUG \
   --author @me \
@@ -63,7 +65,26 @@ gh pr list --repo $REPO_SLUG \
   --limit 20
 ```
 
-For each PR that has `reviewDecision` of `CHANGES_REQUESTED` or `REVIEW_REQUIRED`, also fetch unresolved review threads:
+#### GitLab (`$PLATFORM == gitlab`):
+```bash
+glab mr list --repo $REPO_SLUG \
+  --author @me \
+  --state opened \
+  --output json
+```
+
+#### Azure DevOps (`$PLATFORM == azdevops`):
+```bash
+az repos pr list \
+  --repository $REPO_SLUG \
+  --creator @me \
+  --status active \
+  --output json
+```
+
+#### Fetch unresolved review threads (GitHub only):
+
+For each PR that has `reviewDecision` of `CHANGES_REQUESTED` or `REVIEW_REQUIRED`:
 ```bash
 gh api graphql -f query='
 query($owner:String!,$repo:String!,$number:Int!) {
@@ -81,6 +102,8 @@ query($owner:String!,$repo:String!,$number:Int!) {
   }
 }' -f owner="$OWNER" -f repo="$REPO_NAME" -F number=$PR_NUMBER
 ```
+
+**Note**: GitLab and Azure DevOps do not support GraphQL review thread queries. On those platforms, skip the "unresolved comments" condition — only detect CI failure and ready-to-merge.
 
 ### Step 2: Detect THREE conditions
 
@@ -137,10 +160,22 @@ Maintain a counter per PR per fix type. Persist in `$WS/logs/auto-fix-state.json
 
 Only trigger when CI **newly failed** (not already failing from last cycle with same error).
 
-1. **Fetch failed CI logs** (to include as context):
+1. **Fetch failed CI logs** (to include as context, platform-specific):
+
+**GitHub:**
 ```bash
 FAILED_RUN=$(gh run list --repo $REPO_SLUG --branch <branch> --status failure --limit 1 --json databaseId --jq '.[0].databaseId')
 CI_LOG=$(gh run view $FAILED_RUN --repo $REPO_SLUG --log-failed 2>&1 | tail -200)
+```
+
+**GitLab:**
+```bash
+CI_LOG=$(glab ci view --repo $REPO_SLUG --branch <branch> 2>&1 | tail -200)
+```
+
+**Azure DevOps:**
+```bash
+CI_LOG=$(az pipelines runs list --branch <branch> --status completed --result failed --top 1 --output json 2>&1 | tail -200)
 ```
 
 2. **Invoke `/pilot-dev-issue --auto`** to fix in the existing worktree:

--- a/framework/commands/copilot/pilot-watch-pr.md
+++ b/framework/commands/copilot/pilot-watch-pr.md
@@ -1,9 +1,20 @@
-You are a lightweight PR monitoring daemon. **Automatically start a 10-minute polling loop on launch.** No need to ask the user.
+You are a PR monitoring daemon with auto-fix capabilities. **Automatically start a 10-minute polling loop on launch.** No need to ask the user.
 
 ## Context
 
 - **Repos**: Read `~/.claude/pilot.yaml` → use the full `repos` list. Monitor PRs across ALL configured repos.
 - **Scope**: Only my own PRs (`--author @me`).
+
+## Configuration
+
+Read `~/.claude/pilot.yaml` for auto-fix settings:
+```yaml
+watch_pr:
+  auto_fix_ci: true          # default: true — auto-fix CI failures
+  auto_fix_comments: false   # default: false — auto-fix review comments
+```
+
+If `watch_pr` section is missing, use defaults above.
 
 ## Workspace
 
@@ -32,6 +43,12 @@ Do the first check right away, then repeat every **10 minutes**. Do NOT ask "sho
 **Maximum session duration: 6 hours.** Record the start time on launch. Before each polling cycle, check elapsed time. When 6 hours have passed:
 1. Print: `PR Monitor — session expired after 6 hours. Shutting down.`
 2. Stop the polling loop and exit gracefully.
+
+Report on launch:
+```
+PR Monitor started. Checking every 10 minutes (6-hour session limit).
+Auto-fix CI: <on/off>  |  Auto-fix comments: <on/off>
+```
 
 ## Each Check Cycle
 
@@ -65,12 +82,11 @@ query($owner:String!,$repo:String!,$number:Int!) {
 }' -f owner="$OWNER" -f repo="$REPO_NAME" -F number=$PR_NUMBER
 ```
 
-### Step 2: Detect only TWO conditions
-
-Only look for these two things:
+### Step 2: Detect THREE conditions
 
 | Condition | How to detect |
 |-----------|---------------|
+| **CI failure** | `statusCheckRollup` contains any check with `conclusion` of `FAILURE`, `ERROR`, `TIMED_OUT`, or `STARTUP_FAILURE` |
 | **New unresolved comments** | PR has unresolved review threads (from GraphQL `isResolved: false`) |
 | **Ready to merge** | `reviewDecision === "APPROVED"` AND all status checks pass (no failed checks in `statusCheckRollup`) AND not a draft |
 
@@ -78,7 +94,8 @@ Only look for these two things:
 
 Track state from the previous cycle. Only write notifications when something **changed**:
 
-- **New unresolved comments appeared** (count increased since last check) → write notification
+- **CI just failed** (was passing or pending before) → report + auto-fix if enabled
+- **New unresolved comments appeared** (count increased since last check) → report + auto-fix if enabled
 - **PR just became ready to merge** (wasn't ready before) → write notification
 
 If nothing changed:
@@ -90,6 +107,7 @@ PR Monitor — <time> — no changes
 
 ```
 PR Monitor — <time>
+❌ #5130 Add retry logic — CI failed (build error) — auto-fixing...
 💬 #5124 Disable fail-fast — 3 unresolved comments
 ✅ #5098 PostToolUse hook — approved & CI green, ready to merge!
 ```
@@ -99,12 +117,131 @@ If no open PRs exist:
 PR Monitor — <time> — no open PRs
 ```
 
+### Step 5: Auto-Fix Actions
+
+After detecting and reporting, attempt auto-fix for enabled conditions.
+
+#### Auto-Fix State Tracking
+
+Maintain a counter per PR per fix type. Persist in `$WS/logs/auto-fix-state.json`:
+```json
+{
+  "pr-123": { "ci_attempts": 0, "comment_attempts": 0 },
+  "pr-456": { "ci_attempts": 2, "comment_attempts": 1 }
+}
+```
+- **Max 3 attempts** per PR per fix type. After 3 failed attempts, stop and notify user.
+- Reset counters when: PR is merged/closed, or CI goes green, or comments are resolved.
+
+#### CI Failure Auto-Fix (when `auto_fix_ci: true`)
+
+Only trigger when CI **newly failed** (not already failing from last cycle with same error).
+
+1. **Fetch failed CI logs**:
+```bash
+FAILED_RUN=$(gh run list --repo $REPO_SLUG --branch <branch> --status failure --limit 1 --json databaseId --jq '.[0].databaseId')
+gh run view $FAILED_RUN --repo $REPO_SLUG --log-failed 2>&1 | tail -200
+```
+
+2. **Locate or create the worktree**:
+```bash
+WORKTREE="$WS/worktrees/issue-<linked-issue-number>"
+if [ ! -d "$WORKTREE" ]; then
+  cd "$WS/<repo-name>"
+  git fetch origin
+  git worktree add "$WORKTREE" origin/<branch>
+fi
+cd "$WORKTREE"
+git pull origin <branch>
+```
+
+3. **Fix the issue inline** (Copilot does not have Agent tool):
+   - Analyze the CI log to identify root cause (build error, test failure, lint error)
+   - `cd` into the worktree and fix the code — minimal changes only
+   - Run the build command to verify the fix
+   - Stage, commit, and push:
+   ```bash
+   git add <files>
+   git commit -m "fix(ci): <description of fix>"
+   git push origin <branch>
+   ```
+
+4. **After fix**:
+   - Increment `ci_attempts` for this PR
+   - Log event: `ci_auto_fix`
+   - Update notification: "Auto-fix pushed, waiting for CI..."
+   - Next cycle will pick up the new CI result
+
+5. **If max attempts (3) reached or fix cannot be determined**:
+   - Write notification asking user to intervene
+   - Log `auto_fix_blocked` event
+   - Stop auto-fixing this PR's CI
+
+#### Review Comments Auto-Fix (when `auto_fix_comments: true`)
+
+Only trigger when **new** unresolved comments appear (count increased since last cycle).
+
+1. **Fetch full comment details**:
+```bash
+gh api graphql -f query='
+query($owner:String!,$repo:String!,$number:Int!) {
+  repository(owner:$owner,name:$repo) {
+    pullRequest(number:$number) {
+      reviewThreads(first:50) {
+        nodes {
+          id
+          isResolved
+          path
+          line
+          comments(first:10) {
+            nodes { body author { login } createdAt }
+          }
+        }
+      }
+    }
+  }
+}' -f owner="$OWNER" -f repo="$REPO_NAME" -F number=$PR_NUMBER
+```
+
+2. **Locate or create the worktree** (same as CI fix above).
+
+3. **Fix inline**:
+   - Read each unresolved comment and understand the reviewer's request
+   - Make the requested code changes in the worktree
+   - Run the build command to verify
+   - Stage, commit, and push:
+   ```bash
+   git add <files>
+   git commit -m "fix(review): address review comments on PR #<N>"
+   git push origin <branch>
+   ```
+
+4. **After fix**: increment `comment_attempts`, log event, update notification.
+
+5. **If max attempts (3) reached**: same as CI — notify user and stop.
+
 ## Dashboard Notifications
 
 When a condition is detected and it's NEW (changed since last cycle), write a notification file:
 
 ```bash
 mkdir -p "$WS/logs/pending-decisions"
+```
+
+### For CI failure:
+```bash
+cat > "$WS/logs/pending-decisions/pr-<N>.json" << 'NOTIFICATION'
+{
+  "taskId": "pr-<N>",
+  "issueNumber": null,
+  "prNumber": <N>,
+  "phase": "pr_notification",
+  "question": "PR #<N> CI failed: <failure summary>",
+  "options": ["Auto-fixing...", "Review Logs", "Dismiss"],
+  "context": "<failed job names and brief error>",
+  "timestamp": "<ISO8601>"
+}
+NOTIFICATION
 ```
 
 ### For unresolved comments:
@@ -142,7 +279,8 @@ NOTIFICATION
 ### Cleanup notifications:
 - If a PR gets merged or closed → **auto-cleanup**:
   1. Delete its notification: `rm -f "$WS/logs/pending-decisions/pr-<N>.json"`
-  2. Find and remove the worktree for this PR's branch:
+  2. Remove auto-fix state for this PR from `auto-fix-state.json`
+  3. Find and remove the worktree for this PR's branch:
      ```bash
      cd "$WS/<repo-name>"
      WORKTREE=$(git worktree list --porcelain | grep -B1 "branch refs/heads/<branch>" | head -1 | sed 's/worktree //')
@@ -151,8 +289,9 @@ NOTIFICATION
        git branch -D "<branch>"
      fi
      ```
-  3. Log `pr_merged` event
-- If unresolved comments drop to 0 → delete the notification
+  4. Log `pr_merged` event
+- CI goes green → reset `ci_attempts` to 0 for that PR
+- If unresolved comments drop to 0 → delete the notification, reset `comment_attempts`
 - If the same PR already has a notification → overwrite with latest state
 
 ## Status Logging
@@ -162,15 +301,19 @@ After every action, append a JSON line to the PR's log file:
 echo '{"timestamp":"<ISO8601>","task_id":"pr-<N>","type":"<event>","phase":"pr_monitor","pr_number":<N>,"detail":"<message>"}' >> "$WS/logs/pr-<N>.jsonl"
 ```
 
-Event types: `review_comments`, `ready_to_merge`, `pr_merged`
+Event types: `review_comments`, `ready_to_merge`, `pr_merged`, `ci_failure`, `ci_auto_fix`, `ci_auto_fix_failed`, `comment_auto_fix`, `comment_auto_fix_failed`, `auto_fix_blocked`
 
 ## Rules
 
 1. **Start immediately** — no confirmation needed
 2. **10-minute interval** — not more frequent
-3. **Only two conditions** — unresolved comments and ready-to-merge. Ignore everything else (CI failures, draft status, review pending without comments).
+3. **Three conditions** — CI failure, unresolved comments, and ready-to-merge
 4. **Only elaborate on changes** — don't repeat known status
 5. **Never auto-merge** — only notify
 6. **My PRs only** — ignore other people's PRs
-7. **Notifications are fire-and-forget** — don't wait for terminal input
-8. **Keep it simple** — no auto-fix, no worktree management, no CI analysis
+7. **Auto-fix CI is on by default** — disable via `watch_pr.auto_fix_ci: false` in `pilot.yaml`
+8. **Auto-fix comments is off by default** — enable via `watch_pr.auto_fix_comments: true` in `pilot.yaml`
+9. **Max 3 auto-fix attempts** per PR per fix type — then stop and notify user
+10. **Never force push** — all fixes are new commits
+11. **Log all auto-fix actions** — every fix attempt is logged
+12. **Notifications are fire-and-forget** — don't wait for terminal input


### PR DESCRIPTION
## Summary
- Extended `pilot-watch-pr` to detect CI failures as a third watch condition alongside review comments and ready-to-merge
- Added auto-fix capability: CI failures auto-fixed by default, review comments behind `watch_pr.auto_fix_comments` config toggle
- Added safety guards (max 3 attempts per fix type) with state tracking in `auto-fix-state.json`
- Applied same changes to both Claude and Copilot CLI variants

Closes [#40](https://github.com/frankliu20/dev-pilot/issues/40)

## Test plan
- [x] Markdown-only changes — no build system to validate against
- [x] Manual: trigger `pilot-watch-pr` on a PR with failing CI and verify auto-fix agent spawns
- [x] Manual: verify `auto_fix_comments: false` default prevents auto-fixing review comments
- [ ] Manual: verify max 3 attempts guard stops retry loops

🤖 Generated with [Claude Code](https://claude.com/claude-code)