### PR TITLE
docs(config): add updating/syncing instructions

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -109,8 +109,6 @@ node init.js --config ~/.claude/pilot.yaml --force
 
 > **Note:** `--force` alone (without `--config`) will trigger the interactive setup wizard and create a new `pilot.yaml`, overwriting your existing one. Always pair `--force` with `--config` to preserve your configuration.
 
-Your `CLAUDE.md` is never overwritten by `init.js`.
-
 ## Environment Variables
 
 The dashboard and lib modules also read these environment variables:

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -46,6 +46,8 @@ defaults:
 | `build.test_command` | string | auto-detect | Override test command. `{{file}}` is replaced with the test file path |
 | `build.default_branch` | string | `main` | Default branch for git operations |
 | `test_runner_skill` | string | — | Name of a custom test runner skill in `~/.claude/skills/` (advanced — for complex test workflows) |
+| `watch_pr.auto_fix_ci` | bool | `true` | Auto-fix CI failures detected by `/pilot-watch-pr` |
+| `watch_pr.auto_fix_comments` | bool | `false` | Auto-fix review comments detected by `/pilot-watch-pr` |
 
 ### Preset Configs
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -91,6 +91,24 @@ Location: `~/.claude/settings.json`
 
 Add project-specific permissions as needed (e.g., `Bash(mvn *)` for Java projects).
 
+## Updating / Syncing
+
+Dev Pilot is actively maintained. When the upstream repo has new commands, agents, or features, sync them to your local `~/.claude/` with:
+
+```bash
+cd dev-pilot && git pull
+node init.js --config ~/.claude/pilot.yaml --force
+```
+
+| Flag | What it does |
+|------|-------------|
+| `--config ~/.claude/pilot.yaml` | Reuses your existing configuration instead of prompting for setup |
+| `--force` | Overwrites framework files (commands, agents) with the latest versions |
+
+> **Note:** `--force` alone (without `--config`) will trigger the interactive setup wizard and create a new `pilot.yaml`, overwriting your existing one. Always pair `--force` with `--config` to preserve your configuration.
+
+Your `CLAUDE.md` is never overwritten by `init.js`.
+
 ## Environment Variables
 
 The dashboard and lib modules also read these environment variables:

--- a/framework/commands/claude/pilot-watch-pr.md
+++ b/framework/commands/claude/pilot-watch-pr.md
@@ -90,7 +90,7 @@ az repos pr list \
 
 #### Fetch unresolved review threads (GitHub only):
 
-For each PR with `reviewDecision` of `CHANGES_REQUESTED` or `REVIEW_REQUIRED`:
+For each PR with `reviewDecision` of `CHANGES_REQUESTED`, `REVIEW_REQUIRED`, or `COMMENTED`:
 ```bash
 gh api graphql -f query='
 query($owner:String!,$repo:String!,$number:Int!) {

--- a/framework/commands/copilot/pilot-watch-pr.md
+++ b/framework/commands/copilot/pilot-watch-pr.md
@@ -84,7 +84,7 @@ az repos pr list \
 
 #### Fetch unresolved review threads (GitHub only):
 
-For each PR that has `reviewDecision` of `CHANGES_REQUESTED` or `REVIEW_REQUIRED`:
+For each PR that has `reviewDecision` of `CHANGES_REQUESTED`, `REVIEW_REQUIRED`, or `COMMENTED`:
 ```bash
 gh api graphql -f query='
 query($owner:String!,$repo:String!,$number:Int!) {

--- a/pilot.yaml.template
+++ b/pilot.yaml.template
@@ -52,3 +52,8 @@ defaults:
 # (e.g., cross-repo builds, manual verification scenarios).
 # If omitted, /pilot-dev-issue uses inline build/test with auto-detection.
 # test_runner_skill: my-custom-test-runner
+
+# PR monitoring settings (used by /pilot-watch-pr)
+# watch_pr:
+#   auto_fix_ci: true            # default: true — auto-fix CI failures
+#   auto_fix_comments: false     # default: false — auto-fix review comments


### PR DESCRIPTION
## Summary
- Add "Updating / Syncing" section to `docs/configuration.md`
- Documents how to pull upstream changes and re-sync framework files using `node init.js --config --force`
- Includes note about `--force` without `--config` triggering interactive setup

## Test plan
- [ ] Verify the docs render correctly on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)