### PR TITLE
fix(dashboard): use issue.url for cross-repo issue links

### DIFF
--- a/dashboard/app/components/IssueDetail.tsx
+++ b/dashboard/app/components/IssueDetail.tsx
@@ -3,7 +3,7 @@
 import { useState } from 'react';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
-import { GHIssue, ClaudeTask, TaskPhase, REPO_URL } from '@/lib/types';
+import { GHIssue, ClaudeTask, TaskPhase } from '@/lib/types';
 
 type FixMode = 'normal' | 'auto';
 
@@ -49,7 +49,7 @@ export default function IssueDetail({ issue, loading, tasks, onBack, onAssign }:
 
       <div className="detail-header">
         <a
-          href={`${REPO_URL}/issues/${issue.number}`}
+          href={issue.url}
           target="_blank"
           rel="noopener noreferrer"
           className="detail-number"
@@ -103,7 +103,7 @@ export default function IssueDetail({ issue, loading, tasks, onBack, onAssign }:
           </button>
         )}
         <a
-          href={`${REPO_URL}/issues/${issue.number}`}
+          href={issue.url}
           target="_blank"
           rel="noopener noreferrer"
           className="github-link"

--- a/dashboard/app/components/IssuePanel.tsx
+++ b/dashboard/app/components/IssuePanel.tsx
@@ -59,7 +59,7 @@ export default function IssuePanel({ issue, loading, tasks, onClose, onAssign }:
         {/* Header */}
         <div className={styles.header}>
           <a
-            href={`${REPO_URL}/issues/${issue.number}`}
+            href={issue.url}
             target="_blank"
             rel="noopener noreferrer"
             className={styles.issueNumber}
@@ -154,7 +154,7 @@ export default function IssuePanel({ issue, loading, tasks, onClose, onAssign }:
             </Button>
           )}
           <a
-            href={`${REPO_URL}/issues/${issue.number}`}
+            href={issue.url}
             target="_blank"
             rel="noopener noreferrer"
             className={styles.githubLink}

--- a/dashboard/app/components/IssuesTab.tsx
+++ b/dashboard/app/components/IssuesTab.tsx
@@ -4,7 +4,7 @@ import React, { useState, useMemo, useCallback } from 'react';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 import rehypeRaw from 'rehype-raw';
-import { GHIssue, ClaudeTask, TaskPhase, REPO_URL } from '@/lib/types';
+import { GHIssue, ClaudeTask, TaskPhase } from '@/lib/types';
 import { PHASE_CONFIG, ACTIVE_PHASES } from '@/lib/constants';
 import Icon from './ui/Icon';
 import Badge from './ui/Badge';
@@ -244,7 +244,7 @@ export default function IssuesTab({ issues, tasks, loading, onRefresh, onAssign,
                   >
                     <td className={styles.colNumber}>
                       <a
-                        href={`${REPO_URL}/issues/${issue.number}`}
+                        href={issue.url}
                         target="_blank"
                         rel="noopener noreferrer"
                         className={styles.issueNumber}

--- a/dashboard/app/page.tsx
+++ b/dashboard/app/page.tsx
@@ -90,7 +90,7 @@ function DashboardInner() {
   const cliDisplayName = CLI_TOOL_CONFIG[cliTool].displayName;
 
   const handleAssign = useCallback(async (issue: GHIssue, mode: 'normal' | 'auto' = 'normal', force: boolean = false) => {
-    const issueUrl = `${REPO_URL}/issues/${issue.number}`;
+    const issueUrl = issue.url;
     try {
       const res = await fetch('/api/tasks/assign', {
         method: 'POST',


### PR DESCRIPTION
## Summary
- Fixed issue links navigating to wrong repo when multiple repos are configured in pilot.yaml
- Dashboard components (IssuesTab, IssuePanel, IssueDetail, page.tsx) were using hardcoded `REPO_URL` to construct issue links, always pointing to the primary repo
- Now uses `issue.url` from GitHub CLI which contains the correct full URL for each issue's actual repo

## Test plan
- [ ] Configure multiple repos in pilot.yaml
- [ ] Open dashboard and verify issue links point to correct repos
- [ ] Verify PR links still work correctly (unchanged, using fallback)

🤖 Generated with [Claude Code](https://claude.com/claude-code)